### PR TITLE
correct and refactor the instance analyzer feature

### DIFF
--- a/canvas-plugin-assistant/agents/instance-analyzer.md
+++ b/canvas-plugin-assistant/agents/instance-analyzer.md
@@ -8,179 +8,19 @@ model: sonnet
 
 You help solutions consultants understand a Canvas Medical instance's configuration before building plugins. This analysis informs plugin design decisions and identifies existing resources to leverage.
 
-## When to Use This Agent
+## Instructions
 
-Use this agent when:
-- Starting a new plugin project and need to understand the target environment
-- Need to know what teams, roles, or questionnaires exist for plugin integration
-- Want to document current instance configuration for reference
-- Checking what plugins are already installed
+Follow the **instance-analyze** skill for the complete workflow:
 
-## Workflow
+1. Get the target instance name (ask user or use provided argument)
+2. Read credentials from `~/.canvas/credentials.ini`
+3. Run the scraper script to fetch configuration
+4. Generate a comprehensive markdown report
+5. Save to `{workspace_dir}/.cpa-workflow-artifacts/instance-config-{hostname}.md`
 
-### Step 1: Get Instance Information
+The skill contains:
+- Detailed step-by-step workflow
+- Report format template
+- Credentials setup instructions
+- Integration with plugin-spec.md
 
-Ask the user which instance to analyze:
-
-```json
-{
-  "questions": [
-    {
-      "question": "What Canvas instance should I analyze?",
-      "header": "Instance",
-      "options": [
-        {"label": "plugin-testing", "description": "Canvas test/sandbox instance"},
-        {"label": "Other", "description": "I'll provide the hostname"}
-      ],
-      "multiSelect": false
-    }
-  ]
-}
-```
-
-### Step 2: Read Credentials and Fetch Configuration
-
-Read credentials from `~/.canvas/credentials.ini`:
-
-```bash
-# Read the credentials file to get root_password for the instance
-cat ~/.canvas/credentials.ini
-```
-
-The instance section should contain:
-```ini
-[instance-name]
-client_id=xxx
-client_secret=yyy
-root_password=zzz
-```
-
-If `root_password` is missing, tell the user:
-> "Please add `root_password` to your `~/.canvas/credentials.ini` under the `[{instance}]` section, then try again."
-
-Use browser automation to:
-
-1. **Login to Admin Portal**
-   - Navigate to `https://{hostname}.canvasmedical.com/admin/`
-   - Username: `root`
-   - Password: `root_password` from credentials.ini
-
-2. **Extract Configuration** from these pages:
-   - `/admin/core/careteamrole/` - Roles
-   - `/admin/core/team/` - Teams
-   - `/admin/core/questionnaire/` - Questionnaires
-   - `/admin/core/notetypelabel/` - Note types
-   - `/admin/scheduling/appointmenttypecategory/` - Appointment types
-   - `/admin/plugin/pluginiopackage/` - Installed plugins
-
-### Step 3: Generate Report
-
-Create a comprehensive markdown report:
-
-```markdown
-# Canvas Instance Configuration Report
-
-**Instance**: {hostname}.canvasmedical.com
-**Generated**: {date}
-
-## Summary
-
-| Category | Count |
-|----------|-------|
-| Roles | X |
-| Teams | X |
-| Questionnaires | X |
-| Note Types | X |
-| Appointment Types | X |
-| Installed Plugins | X |
-
-## Roles
-
-| Name | Description |
-|------|-------------|
-| ... | ... |
-
-## Teams
-
-| Name | Members | Description |
-|------|---------|-------------|
-| ... | ... | ... |
-
-## Questionnaires
-
-| Name | Code | Status |
-|------|------|--------|
-| ... | ... | Active/Inactive |
-
-## Note Types
-
-| Name | Category |
-|------|----------|
-| ... | ... |
-
-## Appointment Types
-
-| Name | Duration | Category |
-|------|----------|----------|
-| ... | ... | ... |
-
-## Installed Plugins
-
-| Name | Version | Status |
-|------|---------|--------|
-| ... | ... | Active/Inactive |
-
-## Plugin Development Recommendations
-
-Based on this configuration:
-
-- **Available Teams for Task Assignment**: [list teams that could receive tasks]
-- **Relevant Questionnaires**: [questionnaires that might be relevant to the use case]
-- **Existing Plugins**: [any plugins that might conflict or complement new development]
-```
-
-### Step 4: Save Report
-
-Save the report to `instance-config-{hostname}.md` in the current working directory.
-
-Tell the user the file path and offer to explain any section in detail.
-
-## Important Notes
-
-1. **Credentials Security**: Never log or store credentials. Use them only for the session.
-
-2. **Read-Only**: This agent only reads configuration. It does not modify anything.
-
-3. **Relevance Filtering**: When presenting the report, highlight items most relevant to the plugin being developed (if known from a previous brainstorming session).
-
-4. **Plugin Conflicts**: Flag any installed plugins that might interact with what's being built.
-
-## Integration with Brainstorm Agent
-
-If a `{workspace_dir}/.cpa-workflow-artifacts/plugin-spec.md` file exists (where workspace_dir is git repository root), read it and tailor the report to highlight:
-- Teams that match the spec's task assignment needs
-- Questionnaires relevant to the spec's data requirements
-- Existing plugins that might overlap
-
-## Example Usage
-
-**User**: "I need to analyze the plugin-testing instance before building a vitals alert plugin"
-
-**You**: *[Uses AskUserQuestion to confirm instance]*
-
-**User**: Confirms plugin-testing
-
-**You**: "I'll need admin credentials to fetch the configuration. Please provide them securely."
-
-**User**: Provides credentials
-
-**You**: *[Fetches configuration from admin pages]*
-
-**You**: "I've analyzed the plugin-testing instance and saved the report to `instance-config-plugin-testing.md`.
-
-Key findings relevant to your vitals alert plugin:
-- **3 clinical teams** available for task assignment: Nursing, Care Coordination, Providers
-- **No existing vitals-related plugins** installed - no conflicts expected
-- **12 active questionnaires** - none specifically for vitals alerts
-
-Would you like me to explain any section in more detail?"

--- a/canvas-plugin-assistant/commands/analyze-instance.md
+++ b/canvas-plugin-assistant/commands/analyze-instance.md
@@ -4,34 +4,6 @@ Analyze a Canvas instance's configuration to understand the target environment.
 
 ## Instructions
 
-Use the **instance-analyzer** agent to document the Canvas instance configuration.
+Use the **instance-analyzer** agent to analyze the Canvas instance configuration. The agent will use the **instance-analyze** skill for detailed guidance.
 
-1. Ask which Canvas instance to analyze (e.g., plugin-testing, customer dev instance)
-2. Read credentials from `~/.canvas/credentials.ini`:
-   - The instance section should contain `client_id`, `client_secret`, and `root_password`
-   - If `root_password` is missing, tell the user to add it to their credentials file
-3. Extract configuration from admin portal using the root_password:
-   - Roles
-   - Teams
-   - Questionnaires
-   - Note types
-   - Appointment types
-   - Installed plugins
-4. Generate `instance-config-{hostname}.md` report
-5. If `{workspace_dir}/.cpa-workflow-artifacts/plugin-spec.md` exists (where workspace_dir is the git repository root), highlight configuration relevant to the planned plugin
-
-## Credentials Setup
-
-If the user hasn't configured credentials, instruct them:
-
-> Add `root_password` to your `~/.canvas/credentials.ini` under the instance section:
-> ```ini
-> [plugin-testing]
-> client_id=your_client_id
-> client_secret=your_client_secret
-> root_password=your_admin_password
-> ```
-
-## Arguments
-
-If the user provides an instance name with the command (e.g., `/analyze-instance plugin-testing`), use that as the target instance.
+If the user provides an instance name with the command (e.g., `/analyze-instance plugin-testing`), pass that to the agent as the target instance.

--- a/canvas-plugin-assistant/scripts/scrape_canvas_instance.py
+++ b/canvas-plugin-assistant/scripts/scrape_canvas_instance.py
@@ -1,0 +1,386 @@
+import re
+import sys
+from datetime import datetime
+from html.parser import HTMLParser
+
+import requests
+
+
+class CSRFTokenParser(HTMLParser):
+    """Parser to extract CSRF token from login page."""
+
+    def __init__(self):
+        super().__init__()
+        self.csrf_token: str | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple]) -> None:
+        if tag == 'input':
+            attrs_dict = dict(attrs)
+            if attrs_dict.get('name') == 'csrfmiddlewaretoken':
+                self.csrf_token = attrs_dict.get('value')
+
+
+class AdminTableParser(HTMLParser):
+    """Parser to extract table data from Django admin pages."""
+
+    def __init__(self):
+        super().__init__()
+        self.in_table = False
+        self.in_thead = False
+        self.in_tbody = False
+        self.in_row = False
+        self.in_cell = False
+        self.in_link = False
+        self.current_cell_classes: list[str] = []
+        self.current_cell_text = ""
+        self.current_row: dict[str, str] = {}
+        self.rows: list[dict[str, str]] = []
+        self.table_found = False
+
+    def handle_starttag(self, tag: str, attrs: list[tuple]) -> None:
+        attrs_dict = dict(attrs)
+        classes = attrs_dict.get('class', '').split()
+
+        if tag == 'table':
+            if attrs_dict.get('id') == 'result_list':
+                self.in_table = True
+                self.table_found = True
+        elif self.in_table:
+            if tag == 'thead':
+                self.in_thead = True
+            elif tag == 'tbody':
+                self.in_tbody = True
+            elif tag == 'tr' and self.in_tbody:
+                self.in_row = True
+                self.current_row = {}
+            elif tag in ('th', 'td') and self.in_row:
+                if 'action-checkbox' not in classes and 'action-checkbox-column' not in classes:
+                    self.in_cell = True
+                    self.current_cell_classes = classes
+                    self.current_cell_text = ""
+            elif tag == 'a' and self.in_cell:
+                self.in_link = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == 'table' and self.in_table:
+            self.in_table = False
+        elif tag == 'thead':
+            self.in_thead = False
+        elif tag == 'tbody':
+            self.in_tbody = False
+        elif tag == 'tr' and self.in_row:
+            self.in_row = False
+            if self.current_row:
+                self.rows.append(self.current_row)
+            self.current_row = {}
+        elif tag in ('th', 'td') and self.in_cell:
+            self.in_cell = False
+            field_name = self._get_field_name()
+            text = self.current_cell_text.strip()
+            # Remove sorting arrows
+            text = re.sub(r'[▲▼]', '', text).strip()
+            if text:
+                self.current_row[field_name] = text
+            self.current_cell_classes = []
+            self.current_cell_text = ""
+        elif tag == 'a' and self.in_link:
+            self.in_link = False
+
+    def handle_data(self, data: str) -> None:
+        if self.in_cell:
+            self.current_cell_text += data
+
+    def _get_field_name(self) -> str:
+        """Extract field name from cell classes."""
+        for cls in self.current_cell_classes:
+            if cls.startswith('field-'):
+                return cls.replace('field-', '').replace('_', ' ').title()
+        return "Name"
+
+
+class CanvasInstanceScraper:
+    def __init__(self, instance_name: str, root_password: str):
+        self.instance_name = instance_name
+        self.base_url = f"https://{instance_name}.canvasmedical.com"
+        self.admin_url = f"{self.base_url}/admin/"
+        self.username = "root"
+        self.password = root_password
+        self.session = requests.Session()
+
+    def login(self) -> bool:
+        """Login to the Canvas admin portal."""
+        print(f"Logging in to {self.admin_url}login/...")
+
+        # Get the login page to retrieve CSRF token
+        login_url = f"{self.admin_url}login/"
+        response = self.session.get(login_url)
+        if response.status_code != 200:
+            print(f"Failed to access login page: {response.status_code}")
+            return False
+
+        # Parse CSRF token
+        parser = CSRFTokenParser()
+        parser.feed(response.text)
+        csrf_token = parser.csrf_token
+
+        if not csrf_token:
+            print("Could not find CSRF token")
+            return False
+
+        # Prepare login data
+        login_data = {
+            'username': self.username,
+            'password': self.password,
+            'csrfmiddlewaretoken': csrf_token,
+            'next': '/admin/'
+        }
+
+        # Submit login form
+        response = self.session.post(
+            login_url,
+            data=login_data,
+            headers={'Referer': login_url}
+        )
+
+        # Check if login was successful by trying to access admin page
+        admin_response = self.session.get(self.admin_url)
+        if 'Log out' in admin_response.text or admin_response.url == self.admin_url:
+            print("Login successful!")
+            return True
+        else:
+            print("Login failed!")
+            return False
+
+    def extract_table_data(self, url: str) -> list[dict[str, str]]:
+        """Extract data from an admin page table."""
+        print(f"Fetching {url}...")
+        response = self.session.get(url)
+
+        if response.status_code != 200:
+            print(f"Failed to fetch {url}: {response.status_code}")
+            return []
+
+        parser = AdminTableParser()
+        parser.feed(response.text)
+
+        if not parser.table_found:
+            print(f"No results table found at {url}")
+            return []
+
+        return parser.rows
+
+    def get_roles(self) -> list[dict[str, str]]:
+        """Extract care team roles."""
+        return self.extract_table_data(f"{self.admin_url}api/careteamrole/?active__exact=1")
+
+    def get_teams(self) -> list[dict[str, str]]:
+        """Extract teams."""
+        return self.extract_table_data(f"{self.admin_url}api/team/")
+
+    def get_questionnaires(self) -> list[dict[str, str]]:
+        """Extract active questionnaires from all use case categories."""
+        urls = [
+            f"{self.admin_url}api/questionnaire/?active__exact=AC&q=&use_case_in_charting__exact=QUES",
+            f"{self.admin_url}api/questionnaire/?active__exact=AC&q=&use_case_in_charting__exact=ROS",
+            f"{self.admin_url}api/questionnaire/?active__exact=AC&q=&use_case_in_charting__exact=EXAM",
+            f"{self.admin_url}api/questionnaire/?active__exact=AC&q=&use_case_in_charting__exact=SA",
+        ]
+        all_questionnaires = []
+        for url in urls:
+            all_questionnaires.extend(self.extract_table_data(url))
+        return all_questionnaires
+
+    def get_note_types(self) -> list[dict[str, str]]:
+        """Extract note types where is_active is true."""
+        return self.extract_table_data(f"{self.admin_url}api/notetype/")
+
+    def get_appointment_types(self) -> list[dict[str, str]]:
+        """Extract appointment types (note types where is_active and is_schedulable are true)."""
+        return self.extract_table_data(f"{self.admin_url}api/notetype/?is_active__exact=1&is_scheduleable__exact=1&q=")
+
+    def get_installed_plugins(self) -> list[dict[str, str]]:
+        """Extract installed plugins."""
+        return self.extract_table_data(f"{self.admin_url}plugin_io/plugin/?is_enabled__exact=1")
+
+    def generate_report(self) -> str:
+        """Generate a comprehensive configuration report."""
+
+        # Collect all data
+        roles = self.get_roles()
+        teams = self.get_teams()
+        questionnaires = self.get_questionnaires()
+        note_types = self.get_note_types()
+        appointment_types = self.get_appointment_types()
+        installed_plugins = self.get_installed_plugins()
+
+        # Generate report
+        report_lines = [
+            "# Canvas Instance Configuration Report",
+            "",
+            f"**Instance**: {self.instance_name}.canvasmedical.com",
+            f"**Generated**: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            "",
+            "## Summary",
+            "",
+            "| Category | Count |",
+            "|----------|-------|",
+            f"| Roles | {len(roles)} |",
+            f"| Teams | {len(teams)} |",
+            f"| Questionnaires | {len(questionnaires)} |",
+            f"| Note Types | {len(note_types)} |",
+            f"| Appointment Types | {len(appointment_types)} |",
+            f"| Installed Plugins | {len(installed_plugins)} |",
+            "",
+        ]
+
+        # Roles section
+        report_lines.extend([
+            "## Roles",
+            "",
+        ])
+        if roles:
+            if roles[0]:
+                headers = list(roles[0].keys())
+                report_lines.append("| " + " | ".join(headers) + " |")
+                report_lines.append("|" + "|".join([" --- " for _ in headers]) + "|")
+                for role in roles:
+                    report_lines.append("| " + " | ".join([role.get(header, "") for header in headers]) + " |")
+        else:
+            report_lines.append("No roles found.")
+        report_lines.append("")
+
+        # Teams section
+        report_lines.extend([
+            "## Teams",
+            "",
+        ])
+        if teams:
+            if teams[0]:
+                headers = list(teams[0].keys())
+                report_lines.append("| " + " | ".join(headers) + " |")
+                report_lines.append("|" + "|".join([" --- " for _ in headers]) + "|")
+                for team in teams:
+                    report_lines.append("| " + " | ".join([team.get(header, "") for header in headers]) + " |")
+        else:
+            report_lines.append("No teams found.")
+        report_lines.append("")
+
+        # Questionnaires section
+        report_lines.extend([
+            "## Questionnaires",
+            "",
+        ])
+        if questionnaires:
+            if questionnaires[0]:
+                headers = list(questionnaires[0].keys())
+                report_lines.append("| " + " | ".join(headers) + " |")
+                report_lines.append("|" + "|".join([" --- " for _ in headers]) + "|")
+                for questionnaire in questionnaires:
+                    report_lines.append("| " + " | ".join([questionnaire.get(header, "") for header in headers]) + " |")
+        else:
+            report_lines.append("No questionnaires found.")
+        report_lines.append("")
+
+        # Note Types section
+        report_lines.extend([
+            "## Note Types",
+            "",
+        ])
+        if note_types:
+            if note_types[0]:
+                headers = list(note_types[0].keys())
+                report_lines.append("| " + " | ".join(headers) + " |")
+                report_lines.append("|" + "|".join([" --- " for _ in headers]) + "|")
+                for note_type in note_types:
+                    report_lines.append("| " + " | ".join([note_type.get(header, "") for header in headers]) + " |")
+        else:
+            report_lines.append("No note types found.")
+        report_lines.append("")
+
+        # Appointment Types section
+        report_lines.extend([
+            "## Appointment Types",
+            "",
+        ])
+        if appointment_types:
+            if appointment_types[0]:
+                headers = list(appointment_types[0].keys())
+                report_lines.append("| " + " | ".join(headers) + " |")
+                report_lines.append("|" + "|".join([" --- " for _ in headers]) + "|")
+                for appointment_type in appointment_types:
+                    report_lines.append("| " + " | ".join([appointment_type.get(header, "") for header in headers]) + " |")
+        else:
+            report_lines.append("No appointment types found.")
+        report_lines.append("")
+
+        # Installed Plugins section
+        report_lines.extend([
+            "## Installed Plugins",
+            "",
+        ])
+        if installed_plugins:
+            if installed_plugins[0]:
+                headers = list(installed_plugins[0].keys())
+                report_lines.append("| " + " | ".join(headers) + " |")
+                report_lines.append("|" + "|".join([" --- " for _ in headers]) + "|")
+                for plugin in installed_plugins:
+                    report_lines.append("| " + " | ".join([plugin.get(header, "") for header in headers]) + " |")
+        else:
+            report_lines.append("No installed plugins found.")
+        report_lines.append("")
+
+        # Recommendations section
+        report_lines.extend([
+            "## Plugin Development Recommendations",
+            "",
+            "Based on this configuration:",
+            "",
+        ])
+
+        if teams:
+            team_names = [team.get('Name', team.get('Team name', '')) for team in teams if team]
+            report_lines.append(f"- **Available Teams for Task Assignment**: {', '.join(team_names) if team_names else 'None'}")
+
+        if questionnaires:
+            report_lines.append(f"- **Active Questionnaires**: {len(questionnaires)} questionnaires available")
+
+        if installed_plugins:
+            plugin_names = [plugin.get('Name', plugin.get('Package name', '')) for plugin in installed_plugins if plugin]
+            report_lines.append(f"- **Existing Plugins**: {', '.join(plugin_names) if plugin_names else 'None'}")
+        else:
+            report_lines.append("- **Existing Plugins**: No plugins currently installed")
+
+        report_lines.append("")
+
+        return "\n".join(report_lines)
+
+    @classmethod
+    def main(cls, argv: list[str]) -> None:
+        """Entry point for CLI execution."""
+        if len(argv) < 3:
+            print("Usage: python scrape_canvas_instance.py <instance_name> <root_password>")
+            sys.exit(1)
+
+        instance_name = argv[1]
+        root_password = argv[2]
+
+        scraper = cls(instance_name, root_password)
+
+        if not scraper.login():
+            print("Failed to login. Exiting.")
+            sys.exit(1)
+
+        report = scraper.generate_report()
+
+        # Save report
+        output_file = f"instance-config-{instance_name}.md"
+        with open(output_file, 'w') as file:
+            file.write(report)
+
+        print(f"\nReport generated: {output_file}")
+        print("\n" + "=" * 80)
+        print(report)
+
+
+if __name__ == "__main__":
+    CanvasInstanceScraper.main(sys.argv)

--- a/canvas-plugin-assistant/skills/instance-analyze/SKILL.md
+++ b/canvas-plugin-assistant/skills/instance-analyze/SKILL.md
@@ -1,0 +1,229 @@
+---
+name: instance-analyze
+description: Analyze Canvas instance configuration to understand the target environment for plugin development
+---
+
+# Instance Analysis Skill
+
+This skill provides guidance for analyzing a Canvas Medical instance's configuration before building plugins. The analysis informs plugin design decisions and identifies existing resources to leverage.
+
+## When to Use This Skill
+
+Use this skill when:
+- Starting a new plugin project and need to understand the target environment
+- Need to know what teams, roles, or questionnaires exist for plugin integration
+- Want to document current instance configuration for reference
+- Checking what plugins are already installed
+
+## Workflow
+
+### Step 1: Understand Plugin Intent
+
+First, ask the user about the plugin they intend to build. This helps identify if there's already a related plugin and tailors the analysis to their specific needs.
+
+```json
+{
+  "questions": [
+    {
+      "question": "What plugin are you planning to build? Please describe its purpose briefly.",
+      "header": "Plugin Intent",
+      "options": [
+        {"label": "Clinical Alert", "description": "Alerts for vitals, lab results, or clinical conditions"},
+        {"label": "Workflow Automation", "description": "Automate tasks, appointments, or care coordination"},
+        {"label": "Data Integration", "description": "Sync data with external systems or EHRs"},
+        {"label": "Patient Engagement", "description": "Patient messaging, reminders, or education"}
+      ],
+      "multiSelect": false
+    }
+  ]
+}
+```
+
+Store the user's response to use later when:
+- Checking for existing plugins that might overlap or conflict
+- Highlighting relevant teams, questionnaires, and note types in the report
+- Making plugin development recommendations
+
+### Step 2: Discover Available Instances
+
+Read credentials from `~/.canvas/credentials.ini` to discover configured instances:
+
+```bash
+cat ~/.canvas/credentials.ini
+```
+
+Parse the file to extract all section names (instance names). Each section represents a configured Canvas instance:
+
+```ini
+[instance-name]
+client_id=xxx
+client_secret=yyy
+root_password=zzz
+```
+
+### Step 3: Get Instance Information
+
+Ask the user which instance to analyze using AskUserQuestion, dynamically populating the options with instances discovered in Step 2:
+
+```json
+{
+  "questions": [
+    {
+      "question": "What Canvas instance should I analyze?",
+      "header": "Instance",
+      "options": [
+        {"label": "<instance-1>", "description": "From credentials.ini"},
+        {"label": "<instance-2>", "description": "From credentials.ini"},
+        {"label": "...", "description": "Add all discovered instances"}
+      ],
+      "multiSelect": false
+    }
+  ]
+}
+```
+
+If the user provides an instance name with the command (e.g., `/analyze-instance plugin-testing`), use that directly without asking.
+
+After the user selects an instance, verify it has `root_password` configured. If missing, tell the user:
+
+> Please add `root_password` to your `~/.canvas/credentials.ini` under the `[{instance}]` section:
+> ```ini
+> [plugin-testing]
+> client_id=your_client_id
+> client_secret=your_client_secret
+> root_password=your_admin_password
+> ```
+
+### Step 4: Fetch Configuration
+
+Use the scraper script to extract configuration from the admin portal:
+
+```bash
+uv run python ${CLAUDE_PLUGIN_ROOT}/scripts/scrape_canvas_instance.py <instance_name> <root_password>
+```
+
+This script uses browser automation to:
+
+1. **Login to Admin Portal**
+   - Navigate to `https://{hostname}.canvasmedical.com/admin/`
+   - Username: `root`
+   - Password: `root_password` from credentials.ini
+
+2. **Extract Configuration** from these pages:
+   - `/admin/api/careteamrole/` - Roles (where `is active` is true)
+   - `/admin/api/team/` - Teams
+   - `/admin/api/questionnaire/` - Questionnaires (where `is active` is true)
+   - `/admin/api/notetype/` - Note types (where `is active` is true)
+   - `/admin/api/notetype/` - Appointment types (where `is active` and `is schedulable` are true)
+   - `/admin/plugin_io/plugin/` - Installed plugins
+
+### Step 5: Generate Report
+
+Create a comprehensive markdown report with this structure:
+
+```markdown
+# Canvas Instance Configuration Report
+
+**Instance**: {hostname}.canvasmedical.com
+**Generated**: {date}
+
+## Summary
+
+| Category | Count |
+|----------|-------|
+| Roles | X |
+| Teams | X |
+| Questionnaires | X |
+| Note Types | X |
+| Appointment Types | X |
+| Installed Plugins | X |
+
+## Roles
+
+| Name | Description |
+|------|-------------|
+| ... | ... |
+
+## Teams
+
+| Name | Members | Description |
+|------|---------|-------------|
+| ... | ... | ... |
+
+## Questionnaires
+
+| Name | Code | Status |
+|------|------|--------|
+| ... | ... | Active/Inactive |
+
+## Note Types
+
+| Name | Category |
+|------|----------|
+| ... | ... |
+
+## Appointment Types
+
+| Name | Duration | Category |
+|------|----------|----------|
+| ... | ... | ... |
+
+## Installed Plugins
+
+| Name | Version | Status |
+|------|---------|--------|
+| ... | ... | Active/Inactive |
+
+## Plugin Development Recommendations
+
+Based on this configuration:
+
+- **Available Teams for Task Assignment**: [list teams that could receive tasks]
+- **Relevant Questionnaires**: [questionnaires that might be relevant to the use case]
+- **Existing Plugins**: [any plugins that might conflict or complement new development]
+```
+
+### Step 6: Save Report
+
+Save the report to `instance-config-{hostname}.md` in the current working directory.
+
+Tell the user the file path and offer to explain any section in detail.
+
+## Integration with Plugin Spec
+
+If `{workspace_dir}/.cpa-workflow-artifacts/plugin-spec.md` exists (where workspace_dir is the git repository root), read it and tailor the report to highlight:
+
+- Teams that match the spec's task assignment needs
+- Questionnaires relevant to the spec's data requirements
+- Existing plugins that might overlap
+
+## Important Notes
+
+1. **Credentials Security**: Never log or store credentials. Use them only for the session.
+
+2. **Read-Only**: This analysis only reads configuration. It does not modify anything.
+
+3. **Relevance Filtering**: When presenting the report, highlight items most relevant to the plugin being developed (if known from a previous brainstorming session).
+
+4. **Plugin Conflicts**: Flag any installed plugins that might interact with what's being built.
+
+## Example Interaction
+
+**User**: "I need to analyze the plugin-testing instance before building a vitals alert plugin"
+
+**You**: *[Uses AskUserQuestion to confirm instance]*
+
+**User**: Confirms plugin-testing
+
+**You**: *[Reads credentials and runs scraper script]*
+
+**You**: """I've analyzed the plugin-testing instance and saved the report to `instance-config-plugin-testing.md`.
+
+Key findings relevant to your vitals alert plugin:
+- **3 clinical teams** available for task assignment: Nursing, Care Coordination, Providers
+- **No existing vitals-related plugins** installed - no conflicts expected
+- **12 active questionnaires** - none specifically for vitals alerts
+
+Would you like me to explain any section in more detail?"""
+
+**User**: Yes / No

--- a/tests/canvas-plugin-assistant/scripts/test_scrape_canvas_instance.py
+++ b/tests/canvas-plugin-assistant/scripts/test_scrape_canvas_instance.py
@@ -1,0 +1,1202 @@
+"""Tests for scrape_canvas_instance module."""
+
+import sys
+from html.parser import HTMLParser
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, mock_open, patch
+
+import pytest
+
+from scrape_canvas_instance import (
+    AdminTableParser,
+    CanvasInstanceScraper,
+    CSRFTokenParser,
+)
+
+
+# =============================================================================
+# CSRFTokenParser Tests
+# =============================================================================
+
+
+class TestCSRFTokenParser:
+    """Tests for CSRFTokenParser class."""
+
+    def test_inheritance(self):
+        """Test CSRFTokenParser inherits from HTMLParser."""
+        tested = CSRFTokenParser
+
+        result = issubclass(tested, HTMLParser)
+
+        expected = True
+        assert result is expected
+
+    def test___init__(self):
+        """Test __init__ initializes csrf_token to None."""
+        tested = CSRFTokenParser()
+
+        result = tested.csrf_token
+
+        expected = None
+        assert result is expected
+
+    def test_handle_starttag__finds_csrf_token(self):
+        """Test handle_starttag extracts CSRF token from input field."""
+        tested = CSRFTokenParser()
+        attrs = [("name", "csrfmiddlewaretoken"), ("value", "abc123token")]
+
+        tested.handle_starttag("input", attrs)
+
+        result = tested.csrf_token
+        expected = "abc123token"
+        assert result == expected
+
+    def test_handle_starttag__ignores_non_input_tags(self):
+        """Test handle_starttag ignores non-input tags."""
+        tested = CSRFTokenParser()
+        attrs = [("name", "csrfmiddlewaretoken"), ("value", "abc123token")]
+
+        tested.handle_starttag("div", attrs)
+
+        result = tested.csrf_token
+        expected = None
+        assert result is expected
+
+    def test_handle_starttag__ignores_inputs_without_csrf_name(self):
+        """Test handle_starttag ignores inputs without csrfmiddlewaretoken name."""
+        tested = CSRFTokenParser()
+        attrs = [("name", "username"), ("value", "testuser")]
+
+        tested.handle_starttag("input", attrs)
+
+        result = tested.csrf_token
+        expected = None
+        assert result is expected
+
+
+# =============================================================================
+# AdminTableParser Tests
+# =============================================================================
+
+
+class TestAdminTableParser:
+    """Tests for AdminTableParser class."""
+
+    def test_inheritance(self):
+        """Test AdminTableParser inherits from HTMLParser."""
+        tested = AdminTableParser
+
+        result = issubclass(tested, HTMLParser)
+
+        expected = True
+        assert result is expected
+
+    def test___init__(self):
+        """Test __init__ initializes all attributes correctly."""
+        tested = AdminTableParser()
+
+        assert tested.in_table is False
+        assert tested.in_thead is False
+        assert tested.in_tbody is False
+        assert tested.in_row is False
+        assert tested.in_cell is False
+        assert tested.in_link is False
+        assert tested.current_cell_classes == []
+        assert tested.current_cell_text == ""
+        assert tested.current_row == {}
+        assert tested.rows == []
+        assert tested.table_found is False
+
+    def test_handle_starttag__sets_in_table_for_result_list(self):
+        """Test handle_starttag sets in_table when id is result_list."""
+        tested = AdminTableParser()
+        attrs = [("id", "result_list")]
+
+        tested.handle_starttag("table", attrs)
+
+        assert tested.in_table is True
+        assert tested.table_found is True
+
+    def test_handle_starttag__ignores_table_without_result_list_id(self):
+        """Test handle_starttag ignores tables without result_list id."""
+        tested = AdminTableParser()
+        attrs = [("id", "other_table")]
+
+        tested.handle_starttag("table", attrs)
+
+        result = tested.in_table
+        expected = False
+        assert result is expected
+
+    def test_handle_starttag__sets_in_thead(self):
+        """Test handle_starttag sets in_thead when inside table."""
+        tested = AdminTableParser()
+        tested.in_table = True
+
+        tested.handle_starttag("thead", [])
+
+        result = tested.in_thead
+        expected = True
+        assert result is expected
+
+    def test_handle_starttag__sets_in_tbody(self):
+        """Test handle_starttag sets in_tbody when inside table."""
+        tested = AdminTableParser()
+        tested.in_table = True
+
+        tested.handle_starttag("tbody", [])
+
+        result = tested.in_tbody
+        expected = True
+        assert result is expected
+
+    def test_handle_starttag__sets_in_row_in_tbody(self):
+        """Test handle_starttag sets in_row and resets current_row in tbody."""
+        tested = AdminTableParser()
+        tested.in_table = True
+        tested.in_tbody = True
+        tested.current_row = {"old": "data"}
+
+        tested.handle_starttag("tr", [])
+
+        assert tested.in_row is True
+        assert tested.current_row == {}
+
+    def test_handle_starttag__ignores_tr_outside_tbody(self):
+        """Test handle_starttag ignores tr when not in tbody."""
+        tested = AdminTableParser()
+        tested.in_table = True
+        tested.in_tbody = False
+
+        tested.handle_starttag("tr", [])
+
+        result = tested.in_row
+        expected = False
+        assert result is expected
+
+    def test_handle_starttag__handles_th_cell(self):
+        """Test handle_starttag handles th cell inside row."""
+        tested = AdminTableParser()
+        tested.in_table = True
+        tested.in_row = True
+        attrs = [("class", "field-name sortable")]
+
+        tested.handle_starttag("th", attrs)
+
+        assert tested.in_cell is True
+        assert tested.current_cell_text == ""
+        assert tested.current_cell_classes == ["field-name", "sortable"]
+
+    def test_handle_starttag__handles_td_cell(self):
+        """Test handle_starttag handles td cell inside row."""
+        tested = AdminTableParser()
+        tested.in_table = True
+        tested.in_row = True
+        attrs = [("class", "field-title")]
+
+        tested.handle_starttag("td", attrs)
+
+        assert tested.in_cell is True
+        assert tested.current_cell_classes == ["field-title"]
+
+    def test_handle_starttag__skips_action_checkbox_cell(self):
+        """Test handle_starttag skips action-checkbox cells."""
+        tested = AdminTableParser()
+        tested.in_table = True
+        tested.in_row = True
+        attrs = [("class", "action-checkbox")]
+
+        tested.handle_starttag("td", attrs)
+
+        result = tested.in_cell
+        expected = False
+        assert result is expected
+
+    def test_handle_starttag__skips_action_checkbox_column_cell(self):
+        """Test handle_starttag skips action-checkbox-column cells."""
+        tested = AdminTableParser()
+        tested.in_table = True
+        tested.in_row = True
+        attrs = [("class", "action-checkbox-column")]
+
+        tested.handle_starttag("td", attrs)
+
+        result = tested.in_cell
+        expected = False
+        assert result is expected
+
+    def test_handle_starttag__handles_anchor_in_cell(self):
+        """Test handle_starttag sets in_link when anchor inside cell."""
+        tested = AdminTableParser()
+        tested.in_table = True
+        tested.in_cell = True
+
+        tested.handle_starttag("a", [("href", "/admin/item/1/")])
+
+        result = tested.in_link
+        expected = True
+        assert result is expected
+
+    def test_handle_starttag__ignores_anchor_outside_cell(self):
+        """Test handle_starttag ignores anchor when not in cell."""
+        tested = AdminTableParser()
+        tested.in_table = True
+        tested.in_cell = False
+
+        tested.handle_starttag("a", [("href", "/admin/item/1/")])
+
+        result = tested.in_link
+        expected = False
+        assert result is expected
+
+    def test_handle_endtag__table(self):
+        """Test handle_endtag resets in_table for table end tag."""
+        tested = AdminTableParser()
+        tested.in_table = True
+
+        tested.handle_endtag("table")
+
+        result = tested.in_table
+        expected = False
+        assert result is expected
+
+    def test_handle_endtag__thead(self):
+        """Test handle_endtag resets in_thead for thead end tag."""
+        tested = AdminTableParser()
+        tested.in_thead = True
+
+        tested.handle_endtag("thead")
+
+        result = tested.in_thead
+        expected = False
+        assert result is expected
+
+    def test_handle_endtag__tbody(self):
+        """Test handle_endtag resets in_tbody for tbody end tag."""
+        tested = AdminTableParser()
+        tested.in_tbody = True
+
+        tested.handle_endtag("tbody")
+
+        result = tested.in_tbody
+        expected = False
+        assert result is expected
+
+    def test_handle_endtag__tr_appends_row(self):
+        """Test handle_endtag appends current_row to rows when in row."""
+        tested = AdminTableParser()
+        tested.in_row = True
+        tested.current_row = {"Name": "Test Role"}
+
+        tested.handle_endtag("tr")
+
+        assert tested.in_row is False
+        assert tested.current_row == {}
+        assert tested.rows == [{"Name": "Test Role"}]
+
+    def test_handle_endtag__tr_skips_empty_row(self):
+        """Test handle_endtag skips empty rows."""
+        tested = AdminTableParser()
+        tested.in_row = True
+        tested.current_row = {}
+
+        tested.handle_endtag("tr")
+
+        assert tested.in_row is False
+        assert tested.rows == []
+
+    def test_handle_endtag__td_adds_field_to_row(self):
+        """Test handle_endtag adds field to current_row."""
+        tested = AdminTableParser()
+        tested.in_cell = True
+        tested.current_cell_classes = ["field-name"]
+        tested.current_cell_text = "  Test Name  "
+
+        tested.handle_endtag("td")
+
+        assert tested.in_cell is False
+        assert tested.current_row == {"Name": "Test Name"}
+        assert tested.current_cell_classes == []
+        assert tested.current_cell_text == ""
+
+    def test_handle_endtag__td_removes_sorting_arrows(self):
+        """Test handle_endtag removes sorting arrows from text."""
+        tested = AdminTableParser()
+        tested.in_cell = True
+        tested.current_cell_classes = ["field-name"]
+        tested.current_cell_text = "Test ▲ Name ▼"
+
+        tested.handle_endtag("td")
+
+        assert tested.current_row == {"Name": "Test  Name"}
+
+    def test_handle_endtag__td_skips_empty_text(self):
+        """Test handle_endtag skips adding to row when text is empty."""
+        tested = AdminTableParser()
+        tested.in_cell = True
+        tested.current_cell_classes = ["field-name"]
+        tested.current_cell_text = "   "
+
+        tested.handle_endtag("td")
+
+        assert tested.current_row == {}
+
+    def test_handle_endtag__th_processes_like_td(self):
+        """Test handle_endtag processes th like td."""
+        tested = AdminTableParser()
+        tested.in_cell = True
+        tested.current_cell_classes = ["field-title"]
+        tested.current_cell_text = "Header Text"
+
+        tested.handle_endtag("th")
+
+        assert tested.in_cell is False
+        assert tested.current_row == {"Title": "Header Text"}
+
+    def test_handle_endtag__anchor(self):
+        """Test handle_endtag resets in_link for anchor end tag."""
+        tested = AdminTableParser()
+        tested.in_link = True
+
+        tested.handle_endtag("a")
+
+        result = tested.in_link
+        expected = False
+        assert result is expected
+
+    def test_handle_data__captures_text_in_cell(self):
+        """Test handle_data captures text when in cell."""
+        tested = AdminTableParser()
+        tested.in_cell = True
+        tested.current_cell_text = "Hello "
+
+        tested.handle_data("World")
+
+        result = tested.current_cell_text
+        expected = "Hello World"
+        assert result == expected
+
+    def test_handle_data__ignores_text_outside_cell(self):
+        """Test handle_data ignores text when not in cell."""
+        tested = AdminTableParser()
+        tested.in_cell = False
+        tested.current_cell_text = ""
+
+        tested.handle_data("Ignored text")
+
+        result = tested.current_cell_text
+        expected = ""
+        assert result == expected
+
+    def test__get_field_name__extracts_from_field_class(self):
+        """Test _get_field_name extracts field name from field-* class."""
+        tested = AdminTableParser()
+        tested.current_cell_classes = ["sortable", "field-role_name", "column"]
+
+        result = tested._get_field_name()
+
+        expected = "Role Name"
+        assert result == expected
+
+    def test__get_field_name__returns_name_when_no_field_class(self):
+        """Test _get_field_name returns 'Name' when no field-* class found."""
+        tested = AdminTableParser()
+        tested.current_cell_classes = ["sortable", "column"]
+
+        result = tested._get_field_name()
+
+        expected = "Name"
+        assert result == expected
+
+    def test__get_field_name__returns_name_for_empty_classes(self):
+        """Test _get_field_name returns 'Name' for empty cell_classes."""
+        tested = AdminTableParser()
+        tested.current_cell_classes = []
+
+        result = tested._get_field_name()
+
+        expected = "Name"
+        assert result == expected
+
+
+# =============================================================================
+# CanvasInstanceScraper Tests
+# =============================================================================
+
+
+class TestCanvasInstanceScraper:
+    """Tests for CanvasInstanceScraper class."""
+
+    @patch("scrape_canvas_instance.requests.Session")
+    def test___init__(self, mock_session_class):
+        """Test __init__ initializes all attributes correctly."""
+        mock_session = MagicMock()
+        mock_session_class.side_effect = [mock_session]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        assert tested.instance_name == "demo"
+        assert tested.base_url == "https://demo.canvasmedical.com"
+        assert tested.admin_url == "https://demo.canvasmedical.com/admin/"
+        assert tested.username == "root"
+        assert tested.password == "secret123"
+        assert tested.session == mock_session
+
+        exp_calls = [call()]
+        assert mock_session_class.mock_calls == exp_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    def test_login__success(self, mock_session_class, capsys):
+        """Test login returns True on successful login."""
+        mock_session = MagicMock()
+        mock_session_class.side_effect = [mock_session]
+
+        get_response_login = SimpleNamespace(
+            status_code=200,
+            text='<input name="csrfmiddlewaretoken" value="token123">',
+        )
+        post_response = SimpleNamespace(status_code=200)
+        get_response_admin = SimpleNamespace(
+            status_code=200,
+            text="Welcome! Log out",
+            url="https://demo.canvasmedical.com/admin/",
+        )
+        mock_session.get.side_effect = [get_response_login, get_response_admin]
+        mock_session.post.side_effect = [post_response]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.login()
+
+        expected = True
+        assert result is expected
+
+        captured = capsys.readouterr()
+        assert "Logging in to https://demo.canvasmedical.com/admin/login/..." in captured.out
+        assert "Login successful!" in captured.out
+
+        exp_session_calls = [
+            call.get("https://demo.canvasmedical.com/admin/login/"),
+            call.post(
+                "https://demo.canvasmedical.com/admin/login/",
+                data={
+                    "username": "root",
+                    "password": "secret123",
+                    "csrfmiddlewaretoken": "token123",
+                    "next": "/admin/",
+                },
+                headers={"Referer": "https://demo.canvasmedical.com/admin/login/"},
+            ),
+            call.get("https://demo.canvasmedical.com/admin/"),
+        ]
+        assert mock_session.mock_calls == exp_session_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    def test_login__success_via_url_match(self, mock_session_class, capsys):
+        """Test login returns True when admin URL matches."""
+        mock_session = MagicMock()
+        mock_session_class.side_effect = [mock_session]
+
+        get_response_login = SimpleNamespace(
+            status_code=200,
+            text='<input name="csrfmiddlewaretoken" value="token123">',
+        )
+        post_response = SimpleNamespace(status_code=200)
+        get_response_admin = SimpleNamespace(
+            status_code=200,
+            text="No logout text here",
+            url="https://demo.canvasmedical.com/admin/",
+        )
+        mock_session.get.side_effect = [get_response_login, get_response_admin]
+        mock_session.post.side_effect = [post_response]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.login()
+
+        expected = True
+        assert result is expected
+
+        captured = capsys.readouterr()
+        assert "Logging in to https://demo.canvasmedical.com/admin/login/..." in captured.out
+        assert "Login successful!" in captured.out
+
+        exp_session_calls = [
+            call.get("https://demo.canvasmedical.com/admin/login/"),
+            call.post(
+                "https://demo.canvasmedical.com/admin/login/",
+                data={
+                    "username": "root",
+                    "password": "secret123",
+                    "csrfmiddlewaretoken": "token123",
+                    "next": "/admin/",
+                },
+                headers={"Referer": "https://demo.canvasmedical.com/admin/login/"},
+            ),
+            call.get("https://demo.canvasmedical.com/admin/"),
+        ]
+        assert mock_session.mock_calls == exp_session_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    def test_login__fails_on_get_status_not_200(self, mock_session_class, capsys):
+        """Test login returns False when GET login page fails."""
+        mock_session = MagicMock()
+        mock_session_class.side_effect = [mock_session]
+
+        get_response = SimpleNamespace(status_code=500, text="")
+        mock_session.get.side_effect = [get_response]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.login()
+
+        expected = False
+        assert result is expected
+
+        captured = capsys.readouterr()
+        assert "Failed to access login page: 500" in captured.out
+
+        exp_session_calls = [
+            call.get("https://demo.canvasmedical.com/admin/login/"),
+        ]
+        assert mock_session.mock_calls == exp_session_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    def test_login__fails_when_no_csrf_token(self, mock_session_class, capsys):
+        """Test login returns False when no CSRF token found."""
+        mock_session = MagicMock()
+        mock_session_class.side_effect = [mock_session]
+
+        get_response = SimpleNamespace(
+            status_code=200,
+            text="<html><body>No token here</body></html>",
+        )
+        mock_session.get.side_effect = [get_response]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.login()
+
+        expected = False
+        assert result is expected
+
+        captured = capsys.readouterr()
+        assert "Could not find CSRF token" in captured.out
+
+        exp_session_calls = [
+            call.get("https://demo.canvasmedical.com/admin/login/"),
+        ]
+        assert mock_session.mock_calls == exp_session_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    def test_login__fails_when_login_unsuccessful(self, mock_session_class, capsys):
+        """Test login returns False when login POST fails."""
+        mock_session = MagicMock()
+        mock_session_class.side_effect = [mock_session]
+
+        get_response_login = SimpleNamespace(
+            status_code=200,
+            text='<input name="csrfmiddlewaretoken" value="token123">',
+        )
+        post_response = SimpleNamespace(status_code=200)
+        get_response_admin = SimpleNamespace(
+            status_code=200,
+            text="Invalid credentials",
+            url="https://demo.canvasmedical.com/admin/login/?next=/admin/",
+        )
+        mock_session.get.side_effect = [get_response_login, get_response_admin]
+        mock_session.post.side_effect = [post_response]
+
+        tested = CanvasInstanceScraper("demo", "wrongpass")
+
+        result = tested.login()
+
+        expected = False
+        assert result is expected
+
+        captured = capsys.readouterr()
+        assert "Login failed!" in captured.out
+
+        exp_session_calls = [
+            call.get("https://demo.canvasmedical.com/admin/login/"),
+            call.post(
+                "https://demo.canvasmedical.com/admin/login/",
+                data={
+                    "username": "root",
+                    "password": "wrongpass",
+                    "csrfmiddlewaretoken": "token123",
+                    "next": "/admin/",
+                },
+                headers={"Referer": "https://demo.canvasmedical.com/admin/login/"},
+            ),
+            call.get("https://demo.canvasmedical.com/admin/"),
+        ]
+        assert mock_session.mock_calls == exp_session_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    def test_extract_table_data__success(self, mock_session_class, capsys):
+        """Test extract_table_data returns parsed data on success."""
+        mock_session = MagicMock()
+        mock_session_class.side_effect = [mock_session]
+
+        html_content = """
+        <table id="result_list">
+            <thead><tr><th class="field-name">Name</th></tr></thead>
+            <tbody>
+                <tr><td class="field-name">Role One</td></tr>
+                <tr><td class="field-name">Role Two</td></tr>
+            </tbody>
+        </table>
+        """
+        get_response = SimpleNamespace(status_code=200, text=html_content)
+        mock_session.get.side_effect = [get_response]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+        url = "https://demo.canvasmedical.com/admin/test/?all="
+
+        result = tested.extract_table_data(url)
+
+        expected = [{"Name": "Role One"}, {"Name": "Role Two"}]
+        assert result == expected
+
+        captured = capsys.readouterr()
+        assert "Fetching https://demo.canvasmedical.com/admin/test/?all=..." in captured.out
+
+        exp_session_calls = [call.get(url)]
+        assert mock_session.mock_calls == exp_session_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    def test_extract_table_data__status_not_200(self, mock_session_class, capsys):
+        """Test extract_table_data returns empty list on non-200 status."""
+        mock_session = MagicMock()
+        mock_session_class.side_effect = [mock_session]
+
+        get_response = SimpleNamespace(status_code=404, text="")
+        mock_session.get.side_effect = [get_response]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+        url = "https://demo.canvasmedical.com/admin/test/?all="
+
+        result = tested.extract_table_data(url)
+
+        expected = []
+        assert result == expected
+
+        captured = capsys.readouterr()
+        assert "Failed to fetch https://demo.canvasmedical.com/admin/test/?all=: 404" in captured.out
+
+        exp_session_calls = [call.get(url)]
+        assert mock_session.mock_calls == exp_session_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    def test_extract_table_data__no_table_found(self, mock_session_class, capsys):
+        """Test extract_table_data returns empty list when no table found."""
+        mock_session = MagicMock()
+        mock_session_class.side_effect = [mock_session]
+
+        html_content = "<html><body><p>No table here</p></body></html>"
+        get_response = SimpleNamespace(status_code=200, text=html_content)
+        mock_session.get.side_effect = [get_response]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+        url = "https://demo.canvasmedical.com/admin/test/?all="
+
+        result = tested.extract_table_data(url)
+
+        expected = []
+        assert result == expected
+
+        captured = capsys.readouterr()
+        assert "No results table found at https://demo.canvasmedical.com/admin/test/?all=" in captured.out
+
+        exp_session_calls = [call.get(url)]
+        assert mock_session.mock_calls == exp_session_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch.object(CanvasInstanceScraper, "extract_table_data")
+    def test_get_roles(self, mock_extract, mock_session_class):
+        """Test get_roles calls extract_table_data with correct URL."""
+        mock_extract.side_effect = [[{"Name": "Admin"}]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.get_roles()
+
+        expected = [{"Name": "Admin"}]
+        assert result == expected
+
+        exp_session_class_calls = [call()]
+        assert mock_session_class.mock_calls == exp_session_class_calls
+
+        exp_extract_calls = [
+            call("https://demo.canvasmedical.com/admin/api/careteamrole/?active__exact=1")
+        ]
+        assert mock_extract.mock_calls == exp_extract_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch.object(CanvasInstanceScraper, "extract_table_data")
+    def test_get_teams(self, mock_extract, mock_session_class):
+        """Test get_teams calls extract_table_data with correct URL."""
+        mock_extract.side_effect = [[{"Name": "Team Alpha"}]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.get_teams()
+
+        expected = [{"Name": "Team Alpha"}]
+        assert result == expected
+
+        exp_session_class_calls = [call()]
+        assert mock_session_class.mock_calls == exp_session_class_calls
+
+        exp_extract_calls = [
+            call("https://demo.canvasmedical.com/admin/api/team/")
+        ]
+        assert mock_extract.mock_calls == exp_extract_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch.object(CanvasInstanceScraper, "extract_table_data")
+    def test_get_questionnaires(self, mock_extract, mock_session_class):
+        """Test get_questionnaires loops through 4 URLs and combines results."""
+        mock_extract.side_effect = [
+            [{"Name": "Q1"}],
+            [{"Name": "Q2"}],
+            [],
+            [{"Name": "Q3"}],
+        ]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.get_questionnaires()
+
+        expected = [{"Name": "Q1"}, {"Name": "Q2"}, {"Name": "Q3"}]
+        assert result == expected
+
+        exp_session_class_calls = [call()]
+        assert mock_session_class.mock_calls == exp_session_class_calls
+
+        exp_extract_calls = [
+            call("https://demo.canvasmedical.com/admin/api/questionnaire/?active__exact=AC&q=&use_case_in_charting__exact=QUES"),
+            call("https://demo.canvasmedical.com/admin/api/questionnaire/?active__exact=AC&q=&use_case_in_charting__exact=ROS"),
+            call("https://demo.canvasmedical.com/admin/api/questionnaire/?active__exact=AC&q=&use_case_in_charting__exact=EXAM"),
+            call("https://demo.canvasmedical.com/admin/api/questionnaire/?active__exact=AC&q=&use_case_in_charting__exact=SA"),
+        ]
+        assert mock_extract.mock_calls == exp_extract_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch.object(CanvasInstanceScraper, "extract_table_data")
+    def test_get_note_types(self, mock_extract, mock_session_class):
+        """Test get_note_types calls extract_table_data with correct URL."""
+        mock_extract.side_effect = [[{"Name": "Progress Note"}]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.get_note_types()
+
+        expected = [{"Name": "Progress Note"}]
+        assert result == expected
+
+        exp_session_class_calls = [call()]
+        assert mock_session_class.mock_calls == exp_session_class_calls
+
+        exp_extract_calls = [
+            call("https://demo.canvasmedical.com/admin/api/notetype/")
+        ]
+        assert mock_extract.mock_calls == exp_extract_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch.object(CanvasInstanceScraper, "extract_table_data")
+    def test_get_appointment_types(self, mock_extract, mock_session_class):
+        """Test get_appointment_types calls extract_table_data with correct URL."""
+        mock_extract.side_effect = [[{"Name": "Office Visit"}]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.get_appointment_types()
+
+        expected = [{"Name": "Office Visit"}]
+        assert result == expected
+
+        exp_session_class_calls = [call()]
+        assert mock_session_class.mock_calls == exp_session_class_calls
+
+        exp_extract_calls = [
+            call("https://demo.canvasmedical.com/admin/api/notetype/?is_active__exact=1&is_scheduleable__exact=1&q=")
+        ]
+        assert mock_extract.mock_calls == exp_extract_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch.object(CanvasInstanceScraper, "extract_table_data")
+    def test_get_installed_plugins(self, mock_extract, mock_session_class):
+        """Test get_installed_plugins calls extract_table_data with correct URL."""
+        mock_extract.side_effect = [[{"Name": "My Plugin"}]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.get_installed_plugins()
+
+        expected = [{"Name": "My Plugin"}]
+        assert result == expected
+
+        exp_session_class_calls = [call()]
+        assert mock_session_class.mock_calls == exp_session_class_calls
+
+        exp_extract_calls = [
+            call("https://demo.canvasmedical.com/admin/plugin_io/plugin/?is_enabled__exact=1")
+        ]
+        assert mock_extract.mock_calls == exp_extract_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch("scrape_canvas_instance.datetime")
+    @patch.object(CanvasInstanceScraper, "get_roles")
+    @patch.object(CanvasInstanceScraper, "get_teams")
+    @patch.object(CanvasInstanceScraper, "get_questionnaires")
+    @patch.object(CanvasInstanceScraper, "get_note_types")
+    @patch.object(CanvasInstanceScraper, "get_appointment_types")
+    @patch.object(CanvasInstanceScraper, "get_installed_plugins")
+    def test_generate_report__with_data(
+        self,
+        mock_plugins,
+        mock_apt_types,
+        mock_note_types,
+        mock_questionnaires,
+        mock_teams,
+        mock_roles,
+        mock_datetime,
+        mock_session_class,
+    ):
+        """Test generate_report with data in all sections."""
+        mock_datetime.now.side_effect = [
+            SimpleNamespace(strftime=lambda fmt: "2024-01-15 10:30:00")
+        ]
+
+        mock_roles.side_effect = [[{"Name": "Admin"}, {"Name": "Nurse"}]]
+        mock_teams.side_effect = [[{"Name": "Team A"}]]
+        mock_questionnaires.side_effect = [[{"Name": "PHQ-9"}]]
+        mock_note_types.side_effect = [[{"Name": "Progress Note"}]]
+        mock_apt_types.side_effect = [[{"Name": "Office Visit"}]]
+        mock_plugins.side_effect = [[{"Name": "Plugin1"}]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.generate_report()
+
+        assert "# Canvas Instance Configuration Report" in result
+        assert "**Instance**: demo.canvasmedical.com" in result
+        assert "**Generated**: 2024-01-15 10:30:00" in result
+        assert "## Roles" in result
+        assert "| Name |" in result
+        assert "| Admin |" in result
+        assert "| Nurse |" in result
+        assert "## Teams" in result
+        assert "| Team A |" in result
+        assert "## Questionnaires" in result
+        assert "| PHQ-9 |" in result
+        assert "## Note Types" in result
+        assert "| Progress Note |" in result
+        assert "## Appointment Types" in result
+        assert "| Office Visit |" in result
+        assert "## Installed Plugins" in result
+        assert "| Plugin1 |" in result
+        assert "## Plugin Development Recommendations" in result
+        assert "- **Available Teams for Task Assignment**: Team A" in result
+        assert "- **Active Questionnaires**: 1 questionnaires available" in result
+        assert "- **Existing Plugins**: Plugin1" in result
+
+        exp_calls = [call()]
+        assert mock_roles.mock_calls == exp_calls
+        assert mock_teams.mock_calls == exp_calls
+        assert mock_questionnaires.mock_calls == exp_calls
+        assert mock_note_types.mock_calls == exp_calls
+        assert mock_apt_types.mock_calls == exp_calls
+        assert mock_plugins.mock_calls == exp_calls
+        assert mock_session_class.mock_calls == exp_calls
+
+        exp_datetime_calls = [call.now()]
+        assert mock_datetime.mock_calls == exp_datetime_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch("scrape_canvas_instance.datetime")
+    @patch.object(CanvasInstanceScraper, "get_roles")
+    @patch.object(CanvasInstanceScraper, "get_teams")
+    @patch.object(CanvasInstanceScraper, "get_questionnaires")
+    @patch.object(CanvasInstanceScraper, "get_note_types")
+    @patch.object(CanvasInstanceScraper, "get_appointment_types")
+    @patch.object(CanvasInstanceScraper, "get_installed_plugins")
+    def test_generate_report__empty_data(
+        self,
+        mock_plugins,
+        mock_apt_types,
+        mock_note_types,
+        mock_questionnaires,
+        mock_teams,
+        mock_roles,
+        mock_datetime,
+        mock_session_class,
+    ):
+        """Test generate_report with empty data in all sections."""
+        mock_datetime.now.side_effect = [
+            SimpleNamespace(strftime=lambda fmt: "2024-01-15 10:30:00")
+        ]
+
+        mock_roles.side_effect = [[]]
+        mock_teams.side_effect = [[]]
+        mock_questionnaires.side_effect = [[]]
+        mock_note_types.side_effect = [[]]
+        mock_apt_types.side_effect = [[]]
+        mock_plugins.side_effect = [[]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.generate_report()
+
+        assert "# Canvas Instance Configuration Report" in result
+        assert "No roles found." in result
+        assert "No teams found." in result
+        assert "No questionnaires found." in result
+        assert "No note types found." in result
+        assert "No appointment types found." in result
+        assert "No installed plugins found." in result
+        assert "- **Existing Plugins**: No plugins currently installed" in result
+
+        exp_calls = [call()]
+        assert mock_roles.mock_calls == exp_calls
+        assert mock_teams.mock_calls == exp_calls
+        assert mock_questionnaires.mock_calls == exp_calls
+        assert mock_note_types.mock_calls == exp_calls
+        assert mock_apt_types.mock_calls == exp_calls
+        assert mock_plugins.mock_calls == exp_calls
+        assert mock_session_class.mock_calls == exp_calls
+
+        exp_datetime_calls = [call.now()]
+        assert mock_datetime.mock_calls == exp_datetime_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch("scrape_canvas_instance.datetime")
+    @patch.object(CanvasInstanceScraper, "get_roles")
+    @patch.object(CanvasInstanceScraper, "get_teams")
+    @patch.object(CanvasInstanceScraper, "get_questionnaires")
+    @patch.object(CanvasInstanceScraper, "get_note_types")
+    @patch.object(CanvasInstanceScraper, "get_appointment_types")
+    @patch.object(CanvasInstanceScraper, "get_installed_plugins")
+    def test_generate_report__empty_dict_in_list(
+        self,
+        mock_plugins,
+        mock_apt_types,
+        mock_note_types,
+        mock_questionnaires,
+        mock_teams,
+        mock_roles,
+        mock_datetime,
+        mock_session_class,
+    ):
+        """Test generate_report with empty dict in list (roles[0] is empty)."""
+        mock_datetime.now.side_effect = [
+            SimpleNamespace(strftime=lambda fmt: "2024-01-15 10:30:00")
+        ]
+
+        mock_roles.side_effect = [[{}]]
+        mock_teams.side_effect = [[{}]]
+        mock_questionnaires.side_effect = [[{}]]
+        mock_note_types.side_effect = [[{}]]
+        mock_apt_types.side_effect = [[{}]]
+        mock_plugins.side_effect = [[{}]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.generate_report()
+
+        # When roles[0] is empty dict, it's falsy so no table is generated
+        assert "## Roles" in result
+        assert "## Teams" in result
+        # Empty dicts in teams filter out to empty string join
+        assert "- **Available Teams for Task Assignment**:" in result
+
+        exp_calls = [call()]
+        assert mock_roles.mock_calls == exp_calls
+        assert mock_teams.mock_calls == exp_calls
+        assert mock_questionnaires.mock_calls == exp_calls
+        assert mock_note_types.mock_calls == exp_calls
+        assert mock_apt_types.mock_calls == exp_calls
+        assert mock_plugins.mock_calls == exp_calls
+        assert mock_session_class.mock_calls == exp_calls
+
+        exp_datetime_calls = [call.now()]
+        assert mock_datetime.mock_calls == exp_datetime_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch("scrape_canvas_instance.datetime")
+    @patch.object(CanvasInstanceScraper, "get_roles")
+    @patch.object(CanvasInstanceScraper, "get_teams")
+    @patch.object(CanvasInstanceScraper, "get_questionnaires")
+    @patch.object(CanvasInstanceScraper, "get_note_types")
+    @patch.object(CanvasInstanceScraper, "get_appointment_types")
+    @patch.object(CanvasInstanceScraper, "get_installed_plugins")
+    def test_generate_report__team_name_fallback(
+        self,
+        mock_plugins,
+        mock_apt_types,
+        mock_note_types,
+        mock_questionnaires,
+        mock_teams,
+        mock_roles,
+        mock_datetime,
+        mock_session_class,
+    ):
+        """Test generate_report uses Team name fallback key for teams."""
+        mock_datetime.now.side_effect = [
+            SimpleNamespace(strftime=lambda fmt: "2024-01-15 10:30:00")
+        ]
+
+        mock_roles.side_effect = [[]]
+        mock_teams.side_effect = [[{"Team name": "Alpha Team"}]]
+        mock_questionnaires.side_effect = [[]]
+        mock_note_types.side_effect = [[]]
+        mock_apt_types.side_effect = [[]]
+        mock_plugins.side_effect = [[]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.generate_report()
+
+        assert "- **Available Teams for Task Assignment**: Alpha Team" in result
+
+        exp_calls = [call()]
+        assert mock_roles.mock_calls == exp_calls
+        assert mock_teams.mock_calls == exp_calls
+        assert mock_questionnaires.mock_calls == exp_calls
+        assert mock_note_types.mock_calls == exp_calls
+        assert mock_apt_types.mock_calls == exp_calls
+        assert mock_plugins.mock_calls == exp_calls
+        assert mock_session_class.mock_calls == exp_calls
+
+        exp_datetime_calls = [call.now()]
+        assert mock_datetime.mock_calls == exp_datetime_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch("scrape_canvas_instance.datetime")
+    @patch.object(CanvasInstanceScraper, "get_roles")
+    @patch.object(CanvasInstanceScraper, "get_teams")
+    @patch.object(CanvasInstanceScraper, "get_questionnaires")
+    @patch.object(CanvasInstanceScraper, "get_note_types")
+    @patch.object(CanvasInstanceScraper, "get_appointment_types")
+    @patch.object(CanvasInstanceScraper, "get_installed_plugins")
+    def test_generate_report__plugin_package_name_fallback(
+        self,
+        mock_plugins,
+        mock_apt_types,
+        mock_note_types,
+        mock_questionnaires,
+        mock_teams,
+        mock_roles,
+        mock_datetime,
+        mock_session_class,
+    ):
+        """Test generate_report uses Package name fallback key for plugins."""
+        mock_datetime.now.side_effect = [
+            SimpleNamespace(strftime=lambda fmt: "2024-01-15 10:30:00")
+        ]
+
+        mock_roles.side_effect = [[]]
+        mock_teams.side_effect = [[]]
+        mock_questionnaires.side_effect = [[]]
+        mock_note_types.side_effect = [[]]
+        mock_apt_types.side_effect = [[]]
+        mock_plugins.side_effect = [[{"Package name": "my-plugin-pkg"}]]
+
+        tested = CanvasInstanceScraper("demo", "secret123")
+
+        result = tested.generate_report()
+
+        assert "- **Existing Plugins**: my-plugin-pkg" in result
+
+        exp_calls = [call()]
+        assert mock_roles.mock_calls == exp_calls
+        assert mock_teams.mock_calls == exp_calls
+        assert mock_questionnaires.mock_calls == exp_calls
+        assert mock_note_types.mock_calls == exp_calls
+        assert mock_apt_types.mock_calls == exp_calls
+        assert mock_plugins.mock_calls == exp_calls
+        assert mock_session_class.mock_calls == exp_calls
+
+        exp_datetime_calls = [call.now()]
+        assert mock_datetime.mock_calls == exp_datetime_calls
+
+    def test_main__insufficient_arguments(self, capsys):
+        """Test main exits with code 1 when insufficient arguments provided."""
+        tested = CanvasInstanceScraper
+
+        with pytest.raises(SystemExit) as exc_info:
+            tested.main(["script_name"])
+
+        assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        expected = "Usage: python scrape_canvas_instance.py <instance_name> <root_password>\n"
+        assert captured.out == expected
+
+    def test_main__insufficient_arguments_one_arg(self, capsys):
+        """Test main exits with code 1 when only one argument provided."""
+        tested = CanvasInstanceScraper
+
+        with pytest.raises(SystemExit) as exc_info:
+            tested.main(["script_name", "instance_only"])
+
+        assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        expected = "Usage: python scrape_canvas_instance.py <instance_name> <root_password>\n"
+        assert captured.out == expected
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch.object(CanvasInstanceScraper, "login")
+    def test_main__login_fails(self, mock_login, mock_session_class, capsys):
+        """Test main exits with code 1 when login fails."""
+        mock_login.side_effect = [False]
+
+        tested = CanvasInstanceScraper
+
+        with pytest.raises(SystemExit) as exc_info:
+            tested.main(["script_name", "demo", "secret123"])
+
+        assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        assert "Failed to login. Exiting.\n" in captured.out
+
+        exp_calls = [call()]
+        assert mock_login.mock_calls == exp_calls
+        assert mock_session_class.mock_calls == exp_calls
+
+    @patch("scrape_canvas_instance.requests.Session")
+    @patch.object(CanvasInstanceScraper, "login")
+    @patch.object(CanvasInstanceScraper, "generate_report")
+    @patch("builtins.open", new_callable=mock_open)
+    def test_main__success(
+        self, mock_file_open, mock_generate_report, mock_login, mock_session_class, capsys
+    ):
+        """Test main generates report, writes file, and prints output on success."""
+        mock_login.side_effect = [True]
+        mock_generate_report.side_effect = ["# Report Content"]
+
+        tested = CanvasInstanceScraper
+
+        tested.main(["script_name", "demo", "secret123"])
+
+        captured = capsys.readouterr()
+        assert "\nReport generated: instance-config-demo.md" in captured.out
+        assert "=" * 80 in captured.out
+        assert "# Report Content" in captured.out
+
+        exp_calls = [call()]
+        assert mock_login.mock_calls == exp_calls
+        assert mock_generate_report.mock_calls == exp_calls
+        assert mock_session_class.mock_calls == exp_calls
+
+        exp_file_open_calls = [
+            call("instance-config-demo.md", "w"),
+            call().__enter__(),
+            call().write("# Report Content"),
+            call().__exit__(None, None, None),
+        ]
+        assert mock_file_open.mock_calls == exp_file_open_calls


### PR DESCRIPTION
This PR refactors the instance analyzer by:
- splitting the command and agent into command, agent and skill
- adding the script `canvas-plugin-assistant/scripts/scrape_canvas_instance.py` used by the skill, preventing the (former) agent to build one each time
- correct the URLs to retrieve the data (e.g. using `/admin/api/notetype/` rather than `/admin/core/notetypelabel/`) 
