### PR TITLE
require the deploy command to check the logs immediatly

### DIFF
--- a/canvas-plugin-assistant/agents/deploy-uat.md
+++ b/canvas-plugin-assistant/agents/deploy-uat.md
@@ -1,19 +1,17 @@
 ---
 name: deploy-uat
-description: Deploy Canvas plugins and monitor logs during user acceptance testing
+description: Deploy Canvas plugins — handles version bump, validation, git commit, and install. Does NOT manage log monitoring (parent command owns that).
 model: sonnet
 ---
 
-# Plugin Deployment & UAT Agent
+# Plugin Deployment Agent
 
-You help solutions consultants deploy Canvas plugins and monitor logs during user acceptance testing. You guide the deployment process and help debug issues in real-time.
+You help solutions consultants deploy Canvas plugins. You handle the version bump, pre-deployment validation, git commit/push, and install steps. **You do NOT start, read, or stop log monitoring** — the parent command owns the background log process.
 
 ## When to Use This Agent
 
 Use this agent when:
 - Ready to deploy a plugin to a Canvas instance
-- Need to monitor plugin logs during testing
-- Debugging plugin behavior in a deployed environment
 - Promoting a plugin from dev → staging → production
 
 ## Prerequisites
@@ -26,48 +24,13 @@ Before deployment, verify:
 
 ## Workflow
 
-### Step 1: Confirm Deployment Target
+The parent command passes you a target hostname. Use it directly — do not ask the user to select an environment again.
 
-Use AskUserQuestion to confirm:
+### Step 1: Version Bump (Pre-Deployment)
 
-```json
-{
-  "questions": [
-    {
-      "question": "Which environment should I deploy to?",
-      "header": "Environment",
-      "options": [
-        {"label": "plugin-testing", "description": "Shared test sandbox"},
-        {"label": "Dev instance", "description": "Customer development environment"},
-        {"label": "Staging", "description": "Pre-production environment"},
-        {"label": "Production", "description": "Live production (use caution)"}
-      ],
-      "multiSelect": false
-    },
-    {
-      "question": "Should I monitor logs after deployment?",
-      "header": "Log monitoring",
-      "options": [
-        {"label": "Yes", "description": "Watch logs in real-time for debugging"},
-        {"label": "No", "description": "Just deploy, I'll check logs manually"}
-      ],
-      "multiSelect": false
-    }
-  ]
-}
-```
+**Every deployment MUST bump the plugin version** — this ensures the deployment is visible in the Canvas instance (same version won't show as a new deploy). Always bump, even if there are no code changes.
 
-### Step 2: Version Bump (Pre-Deployment)
-
-**Before deploying, bump the plugin version if there are changes.**
-
-1. Check for uncommitted changes or changes since last deploy:
-   ```bash
-   git status --porcelain
-   git diff --name-only HEAD~1
-   ```
-
-2. If there are changes, determine version bump type and ask user:
+1. Determine version bump type and ask user:
 
 ```json
 {
@@ -101,7 +64,7 @@ Use AskUserQuestion to confirm:
 6. Report the version change:
    > "Bumped version: 0.0.1 → 0.0.2"
 
-### Step 3: Pre-Deployment Validation
+### Step 2: Pre-Deployment Validation
 
 Run these checks before deploying:
 
@@ -126,7 +89,7 @@ uv run mypy --config-file=mypy.ini .
 
 2. **Verify plugin_version was bumped appropriately:**
    - If this is first deployment: version should be `0.0.1`
-   - If code changed since last deploy: version should have been bumped in Step 2
+   - If code changed since last deploy: version should have been bumped in Step 1
    - Version should follow semantic versioning (MAJOR.MINOR.PATCH)
 
 3. **If sdk_version doesn't match:**
@@ -137,7 +100,7 @@ uv run mypy --config-file=mypy.ini .
 
 Report any issues and fix if needed before proceeding.
 
-### Step 4: Git Commit and Push
+### Step 3: Git Commit and Push
 
 **After validation passes, commit all changes before deploying.**
 
@@ -154,20 +117,7 @@ Use concise declarative voice for commit messages:
 - "fix threshold logic, prepare for deployment"
 - "add webhook handler, prepare v0.1.0 for deployment"
 
-### Step 5: Start Log Monitoring (BEFORE install)
-
-**Always start logs before deploying** - this captures installation errors.
-
-Start log streaming as a **background task**:
-
-```bash
-# Start with run_in_background: true
-unbuffer uv run canvas logs --host {hostname}
-```
-
-Save the `bash_id` from the background task - you'll need it to retrieve logs.
-
-### Step 6: Deploy Plugin
+### Step 4: Deploy Plugin
 
 Execute deployment:
 
@@ -181,92 +131,7 @@ uv run canvas install {plugin_name} --host {hostname}
 uv run canvas enable {plugin_name} --host {hostname}
 ```
 
-After install completes, tell the user:
-> "Plugin deployed. Log monitoring is running - go ahead and test in Canvas. Tell me to 'check the logs' when you want to see what happened."
-
-**When the user says to check logs** (e.g., "check the logs", "what happened?", "I just entered vitals"):
-
-1. Use the **BashOutput** tool with the saved bash_id to retrieve buffered output
-2. Analyze the log entries for:
-   - Plugin-specific entries (look for `[{plugin_name}]`)
-   - Event received messages
-   - Effect returned messages
-   - Errors or warnings
-3. Report findings to the user
-4. Wait for next user action
-
-**When testing is complete:**
-- Use **KillShell** to stop the background log stream
-- Summarize what was observed during the session
-
-### Step 7: UAT Guidance
-
-Guide the user through testing:
-
-```markdown
-## UAT Checklist
-
-Based on your plugin specification, test these scenarios:
-
-### Trigger Testing
-- [ ] Trigger the expected event (e.g., enter vitals, create order)
-- [ ] Verify the plugin responds (check logs)
-- [ ] Confirm the expected effect occurs (alert appears, task created, etc.)
-
-### Edge Cases
-- [ ] Test with missing data (what if vitals are incomplete?)
-- [ ] Test with boundary values (exactly at threshold)
-- [ ] Test rapid repeated triggers
-
-### Negative Testing
-- [ ] Verify plugin does NOT fire when conditions aren't met
-- [ ] Check for duplicate effects (idempotency)
-
-### User Experience
-- [ ] Is the alert/task/UI clear and helpful?
-- [ ] Does it appear in the right location?
-- [ ] Is timing appropriate?
-```
-
-### Step 8: Document Results
-
-After testing, create a UAT summary:
-
-```markdown
-# UAT Results: {plugin_name}
-
-**Instance**: {hostname}
-**Date**: {date}
-**Tester**: {user}
-
-## Test Results
-
-| Test Case | Result | Notes |
-|-----------|--------|-------|
-| Basic trigger | Pass/Fail | ... |
-| Edge case 1 | Pass/Fail | ... |
-| ... | ... | ... |
-
-## Issues Found
-
-1. **Issue**: Description
-   **Severity**: High/Medium/Low
-   **Log excerpt**: `...`
-
-## Recommendations
-
-- [ ] Fix issue 1 before production
-- [ ] Consider enhancement X for future
-- [ ] Ready for production deployment
-
-## Next Steps
-
-- [ ] Address issues
-- [ ] Re-test
-- [ ] Deploy to next environment
-```
-
-Save to `uat-results-{plugin_name}-{date}.md`.
+After install completes, **return to the parent command**. The parent handles log checking and UAT from here.
 
 ## After UAT Passes
 
@@ -407,40 +272,36 @@ Debug logs should be removed during wrap-up (`/cpa:wrap-up`). They're useful for
 
 ## Example Session
 
-**User**: "Deploy my vitals alert plugin to plugin-testing for UAT"
+**Parent command**: "Deploy to plugin-testing"
 
-**You**: *[Confirms environment and log monitoring preference]*
+**You**: "Checking for changes..."
+
+```
+✓ Changes detected, bumping version
+Bumped version: 0.0.1 → 0.0.2
+```
 
 **You**: "Running pre-deployment checks..."
 
 ```
 ✓ Manifest valid
 ✓ Tests passing (5/5)
-✓ No existing installation found
+✓ Type checking passed
+```
+
+**You**: "Committing and pushing..."
+
+```
+✓ Committed: prepare vitals-alert v0.0.2 for deployment
+✓ Pushed to origin
 ```
 
 **You**: "Deploying to plugin-testing..."
 
 ```
-Installing vitals-alert v0.0.1...
+Installing vitals-alert v0.0.2...
 ✓ Plugin installed successfully
 ✓ Plugin enabled
 ```
 
-**You**: "Deployment complete! Starting log monitoring...
-
-To test, go to a patient chart in plugin-testing and enter vitals with high blood pressure (systolic > 140).
-
-I'm watching the logs - let me know when you've triggered a test."
-
-**User**: "Just entered vitals with BP 150/95"
-
-**You**: "I see it in the logs:
-
-```
-[vitals-alert] VITALS_COMMAND__POST_COMMIT received for patient abc123
-[vitals-alert] BP 150/95 exceeds threshold, creating alert
-[vitals-alert] AddBannerAlert effect returned
-```
-
-The plugin triggered correctly. Do you see the alert in the patient's timeline?"
+**You**: *[Returns to parent command — parent handles log checking and UAT]*

--- a/canvas-plugin-assistant/commands/deploy.md
+++ b/canvas-plugin-assistant/commands/deploy.md
@@ -26,43 +26,65 @@ uv run python "${CLAUDE_PLUGIN_ROOT}/scripts/validate_cpa_environment.py" --requ
 cd "$CPA_PLUGIN_DIR"
 ```
 
-Use the **deploy-uat** agent to handle deployment and testing.
+### Step 2: Determine Target Hostname
+
+Resolve the deployment target **before** delegating to the agent — the parent needs the hostname to start log monitoring.
 
 1. Verify the current directory contains a valid Canvas plugin (check for CANVAS_MANIFEST.json)
 
 2. **Handle target instance argument:**
    - If `$1` is provided:
      - Check if `[$1]` section exists in `~/.canvas/credentials.ini`
-     - If found: use `$1` as the target hostname and skip to step 4
+     - If found: use `$1` as the target hostname
      - If NOT found: list available instances from credentials.ini and ask the user to choose or correct the name
    - If `$1` is not provided:
-     - Ask which environment to deploy to (current behavior)
+     - Ask which environment to deploy to
 
-3. Ask which environment to deploy to (only if no valid `$1` was provided)
+Save the resolved hostname — you will pass it to the agent and use it for log monitoring.
 
-4. **Version bump (if changes are detected):**
-   - Check `git status --porcelain` for uncommitted changes
-   - Ask the user: Patch (bug fix), Minor (new feature), or Major (breaking change)?
-   - Read current `plugin_version` from `CANVAS_MANIFEST.json`
-   - Bump version: Patch increments Z, Minor increments Y and resets Z, Major increments X and resets Y,Z
-   - Update `CANVAS_MANIFEST.json` with a new version
-   - Report: "Bumped version: X.Y.Z → X.Y.Z+1"
+### Step 3: Start Log Monitoring (BEFORE install)
 
-5. Run pre-deployment validation:
-   - `uv run canvas validate-manifest .`
-   - `uv run pytest` (if tests exist)
-   - `uv run mypy --config-file=mypy.ini .`
+**Start log monitoring in the parent context** so the background process survives the agent lifecycle.
 
-6. **Start log monitoring BEFORE install** (background task with `run_in_background: true`):
-   - `unbuffer uv run canvas logs --host {hostname}`
-   - This captures installation errors and runtime behavior
+Start log streaming as a **background task** (`run_in_background: true`):
 
-7. Deploy using `uv run canvas install`
+```bash
+unbuffer uv run canvas logs --host {hostname}
+```
 
-8. For UAT:
-   - Tell user logs are running to test and say "check the logs" when ready
-   - Use BashOutput to retrieve and analyze log entries on a user request
-   - Use KillShell when testing is complete
+Save the `bash_id` — you will use it later to check logs. This captures installation errors and runtime behavior.
+
+### Step 4: Deploy via Agent
+
+Use the **deploy-uat** agent to handle version bump, validation, git commit/push, and install. Pass the resolved hostname so the agent does not need to ask again.
+
+Tell the agent: "Deploy to {hostname}".
+
+The agent will return when the install is complete.
+
+### Step 5: Post-Deployment Log Check
+
+After the agent returns and the install is complete, check the logs **in the parent context** (you own the background process).
+
+1. Wait 5 seconds for logs to accumulate (`sleep 5`)
+2. Use **BashOutput** with the saved bash_id to retrieve buffered output (this does NOT stop the background process)
+3. Scan for errors (tracebacks, `ERROR`, `Exception`, `RestrictedPython error`, `ModuleNotFoundError`, install failures)
+4. **If errors are found:**
+   1. Stop log monitoring (KillShell)
+   2. Show the errors to the user
+   3. Analyze root cause and fix the code
+   4. Re-deploy (repeat from step 3)
+5. **If no errors:** leave log monitoring running and continue to UAT
+
+### Step 6: UAT
+
+Log monitoring is still running in the background (owned by this parent context).
+
+- Tell user: "Plugin deployed successfully — no errors detected in logs. Log monitoring is running — go ahead and test in Canvas. Tell me to 'check the logs' when you want to see what happened."
+- When the user says "check the logs": use BashOutput with the saved bash_id to retrieve and analyze log entries
+- When testing is complete: use KillShell to stop the background log stream
+
+After successful UAT, guide the user to the next step in the workflow.
 
 ## Credentials
 

--- a/tests/canvas-plugin-assistant/scripts/test_scrape_canvas_instance.py
+++ b/tests/canvas-plugin-assistant/scripts/test_scrape_canvas_instance.py
@@ -1132,7 +1132,7 @@ class TestCanvasInstanceScraper:
         assert exc_info.value.code == 1
 
         captured = capsys.readouterr()
-        expected = "Usage: python scrape_canvas_instance.py <instance_name> <root_password>\n"
+        expected = "Usage: uv run python scrape_canvas_instance.py <instance_name> <root_password>\n"
         assert captured.out == expected
 
     def test_main__insufficient_arguments_one_arg(self, capsys):
@@ -1145,7 +1145,7 @@ class TestCanvasInstanceScraper:
         assert exc_info.value.code == 1
 
         captured = capsys.readouterr()
-        expected = "Usage: python scrape_canvas_instance.py <instance_name> <root_password>\n"
+        expected = "Usage: uv run python scrape_canvas_instance.py <instance_name> <root_password>\n"
         assert captured.out == expected
 
     @patch("scrape_canvas_instance.requests.Session")


### PR DESCRIPTION
This PR modify the `deploy` command to immediately look at the logs after deployment.
If there are errors, the log monitoring is stopped and the issues are fixed.


This PR also fix tests that were failing after the merge from `db_20260225_insist_on_uv` 