### PR TITLE
Document screenshots/ folder convention in plugin-patterns

### DIFF
--- a/canvas-plugin-assistant/skills/plugin-patterns/patterns_context.txt
+++ b/canvas-plugin-assistant/skills/plugin-patterns/patterns_context.txt
@@ -21,6 +21,8 @@ example-plugin-name/              # Container folder (kebab-case)
 └── example_plugin_name/          # Inner folder (snake_case, same name converted)
     ├── CANVAS_MANIFEST.json      # MUST be inside inner folder
     ├── README.md                 # Plugin documentation
+    ├── screenshots/              # Images referenced from README.md
+    │   └── main.png
     └── protocols/
         ├── __init__.py
         └── my_protocol.py
@@ -34,6 +36,7 @@ example-plugin-name/              # Container folder (kebab-case)
 4. **tests/** MUST be at container level, parallel to inner folder
 5. **pyproject.toml** is at container level (for local dev/test only)
 6. **README.md** is inside the inner folder
+7. **`screenshots/`** is inside the inner folder, sibling to `README.md` — this is the canonical home for README images so relative paths like `![](screenshots/main.png)` render on GitHub and Notion without any rewriting. Screenshots are a requirement for open-source publishing; keeping them here keeps the plugin self-contained.
 
 ### Name Conversion
 
@@ -99,6 +102,7 @@ simple-plugin/
 ├── CANVAS_MANIFEST.json
 ├── protocols/
 │   └── handler.py
+├── screenshots/                # Screenshots referenced from README.md
 └── README.md
 ```
 
@@ -171,6 +175,7 @@ medium-plugin/
 ├── utils/
 │   ├── __init__.py
 │   └── helpers.py
+├── screenshots/                # Screenshots referenced from README.md
 └── README.md
 ```
 
@@ -221,6 +226,8 @@ complex-plugin/
 │   └── index.html
 ├── utils/
 │   └── helpers.py
+├── screenshots/                # Screenshots referenced from README.md
+│   └── main.png
 └── README.md
 ```
 


### PR DESCRIPTION
## Summary

Documents a consistent `screenshots/` folder convention for Canvas plugins in the `plugin-patterns` skill. The folder lives **inside the inner plugin folder, as a sibling to `README.md`** so relative paths like `![](screenshots/main.png)` render on GitHub and Notion without any rewriting.

Open-source publishing (per the [Open Source Plugin Publishing Checklist](https://www.notion.so/33a0bd9e403380ee9fccceee3210aeda)) requires screenshots in plugin READMEs, but there's been no canonical location — some plugins drop them in `assets/`, some alongside the README, some omit them entirely. This pins the convention.

## Changes

`canvas-plugin-assistant/skills/plugin-patterns/patterns_context.txt`:

- Added `screenshots/` to the canonical project-structure diagram.
- Added a key rule (rule 7) describing the folder's location and rationale.
- Added `screenshots/` to each of the simple / medium / complex structure templates so scaffolding guidance is consistent across complexity levels.

No behavior change — this is documentation only.

## Test plan

- [x] `SKILL.md` frontmatter unchanged; `patterns_context.txt` still loads.
- [ ] Reviewer: skim the diff for consistency with other directory conventions in the same file.
