### PR TITLE
pytest-forge: add missing verification on the tests

### DIFF
--- a/pytest-forge/agents/test-generator.md
+++ b/pytest-forge/agents/test-generator.md
@@ -109,13 +109,70 @@ def test_fetch_data(mock_api):
     assert mock_api.mock_calls == exp_calls
 ```
 
+## Mock Verification: Object Level Only
+
+**CRITICAL RULE**: verify every mock at the **mock object level** — never at the child attribute level.
+
+```python
+# FORBIDDEN — child attribute level:
+assert mock_auth.validate_request.mock_calls == [call(request=request)]
+assert tested.current_status.mock_calls == [call(FooStatus)]
+
+# CORRECT — object level, child calls appear as call.child_name(...):
+assert mock_auth.mock_calls == [call.validate_request(request=request)]
+assert tested.mock_calls == [call.current_status(FooStatus), call.save_status(status)]
+```
+
+A single `assert mock.mock_calls == [...]` at the top of the mock object covers **all** its child calls at once. This is both shorter and safer: it catches new calls that were added to the source but not anticipated in the test.
+
+## Testing Abstract Classes with `MagicMock(spec=...) + __get__`
+
+When the class under test is abstract or hard to instantiate, use:
+
+```python
+tested = MagicMock(spec=MyAbstractClass)
+tested.method_under_test = MyAbstractClass.method_under_test.__get__(tested)
+```
+
+This runs the **real implementation** of `method_under_test` while keeping all other methods as mocks. After calling:
+
+```python
+result = tested.method_under_test(arg)
+```
+
+Verify **all** interactions through a single `tested.mock_calls` assertion:
+
+```python
+# CORRECT — one comprehensive assertion at object level:
+exp_tested_calls = [
+    call.dependency_a(arg1),
+    call.dependency_b(),
+    call.dependency_c(arg2),
+]
+assert tested.mock_calls == exp_tested_calls
+
+# FORBIDDEN — individual child checks miss future additions:
+assert tested.dependency_a.mock_calls == [call(arg1)]   # method level
+assert tested.dependency_b.mock_calls == [call()]        # method level
+```
+
+If a child dependency needs setup (e.g., it returns a value the real code uses), set it via `side_effect`:
+
+```python
+tested.dependency_a.side_effect = [some_value]
+```
+
+Then include `call.dependency_a(arg1)` in `exp_tested_calls` — the object-level check covers it.
+
 ## Important Reminders
 
 - **ALWAYS** reference pytest-guidelines skill
 - **ALWAYS** use `side_effect` for mocks (never `return_value`)
-- **ALWAYS** verify mocks with `mock_calls`
+- **ALWAYS** verify mocks with `mock_calls` **at the object level** — `assert mock.mock_calls == [...]`
+- **NEVER** verify at child attribute level — `assert mock.child.mock_calls` is forbidden even when it appears to cover the call
 - **ALWAYS** use standard variable names
 - **ALWAYS** use hardcoded expected values (never computed or dynamic)
+- **ALWAYS** assert on the **complete** output using equality (`==`), not on a subset using membership (`in`) or individual element checks — partial assertions let source additions go undetected at 100% line coverage
 - **ALWAYS** use tuple as first parameter in `@pytest.mark.parametrize` (not string)
 - **ALWAYS** test edge cases and error paths
 - **ALWAYS** run tests to verify they pass

--- a/pytest-forge/agents/validate-mock-verification.md
+++ b/pytest-forge/agents/validate-mock-verification.md
@@ -87,6 +87,40 @@ def test_fetch(mock_api, input_val, expected):
 # VIOLATION if mock_api.mock_calls is not verified!
 ```
 
+### VIOLATION: Method-Level Verification Instead of Object-Level
+
+Checking a child attribute's `mock_calls` is a method-level violation, even if it appears to cover the call. This is the most commonly missed violation.
+
+**FORBIDDEN** (child attribute / method level):
+```python
+# VIOLATION: .validate_request is a child of mock_auth — verify mock_auth itself
+assert mock_auth.validate_request.mock_calls == [call(request=request)]
+assert mock_auth.extract_clinic_and_flow.mock_calls == [call(query_params)]
+
+# VIOLATION: .current_status is a child of tested — verify tested itself
+assert tested.current_status.mock_calls == [call(FooStatus)]
+assert tested.save_status.mock_calls == [call(status)]
+```
+
+**CORRECT** (object level — one `mock_calls` per mock object, covering all its child calls):
+```python
+# CORRECT: verify mock_auth at object level; child calls appear as call.child(...)
+assert mock_auth.mock_calls == [
+    call.validate_request(request=request),
+    call.extract_clinic_and_flow(query_params),
+]
+
+# CORRECT: verify tested at object level
+assert tested.mock_calls == [
+    call.current_status(FooStatus),
+    call.save_status(status),
+]
+```
+
+**Why this matters**: verifying individual child attributes only catches the calls you already anticipated. Verifying the parent mock object catches every call — including new ones added later that you didn't plan for.
+
+**Detection rule**: if `assert X.mock_calls` appears where `X` contains a dot (e.g., `mock_auth.validate_request`, `tested.save_status`, `mock_client.session.get`), it is a method-level violation. Flag it and report the correct object-level form.
+
 ## Detection Process
 
 For each test function:
@@ -96,6 +130,7 @@ For each test function:
 3. **Find all .return_value references** - these may need verification
 4. **Find all mock_calls assertions** - `assert xxx.mock_calls == `
 5. **Compare**: Every mock from steps 1-3 should have an assertion from step 4
+6. **Check level**: any `assert A.B.mock_calls` where `A` is a mock object is a method-level violation — flag it even if the mock appears "verified"
 
 ## Output Format
 

--- a/pytest-forge/skills/pytest-guidelines/SKILL.md
+++ b/pytest-forge/skills/pytest-guidelines/SKILL.md
@@ -278,6 +278,44 @@ def test_fetch_data(mock_api):
 
 For detailed naming examples, see `references/naming-conventions.md`.
 
+### Assert Complete Outputs, Not Subsets
+
+**CRITICAL**: When a method produces a collection of outputs (a list, a set of files, written text, created objects), assert on the **complete** output using equality — not on a subset using membership or individual element checks.
+
+Partial assertions let source-level additions (a new item in a loop, a new line in a file, a new key in a dict) go completely undetected even at 100% line coverage.
+
+**FORBIDDEN** (subset / membership checks):
+
+```python
+# WRONG — only checks two of three symlinks; adding a third goes unnoticed
+assert (clinic_home / ".claude").is_symlink()
+assert (clinic_home / ".ssh").is_symlink()
+
+# WRONG — only checks partial file content
+assert "line1" in content
+assert "line2" in content
+```
+
+**CORRECT** (equality on the complete output):
+
+```python
+# CORRECT — equality covers ALL symlinks; adding one fails the test immediately
+created = {p.name for p in clinic_home.iterdir() if p.is_symlink()}
+expected = {".claude", ".ssh", ".gitconfig"}
+assert created == expected
+
+# CORRECT — full file content equality
+expected = "line1\nline2\nline3\n"
+assert content == expected
+```
+
+**Rule of thumb**: if the full expected value is deterministic (a constant tuple, a known list of keys, a fixed file content), use `==`. Reserve `in` / `is_symlink()` / individual element checks only for cases where the output is genuinely partial by design.
+
+This applies everywhere:
+- File contents: assert the complete text, not just that certain lines are present
+- Collections returned by methods: assert the complete list/set, not just selected items
+- Side effects (files created, directories made): verify the complete set of expected side effects
+
 ### Assertion Style
 
 **Singleton Comparisons**: Use `is` (not `==`) when comparing to singletons: `True`, `False`, `None`.


### PR DESCRIPTION
- Require `mock_calls` verification at the mock object level (`assert mock.mock_calls`), not at child attribute level (`assert mock.child.mock_calls`) — the `validate-mock-verification` agent now flags the latter as a violation               
- Require assertions on **complete** outputs using equality, not on subsets using membership or individual element checks
