### PR TITLE
Finish handler-terminology rename across CPA

### DIFF
--- a/canvas-plugin-assistant/agents/plugin-brainstorm.md
+++ b/canvas-plugin-assistant/agents/plugin-brainstorm.md
@@ -218,7 +218,7 @@ cd {plugin_name}
 
 The `canvas init` command creates the correct structure. Only AFTER it completes should you proceed to edit the generated files.
 
-You will likely need to remove some unused placeholder files (e.g., `protocols/my_protocol.py`, `test_models.py`) - that's fine.
+You will likely need to remove some unused placeholder files (e.g., `handlers/my_handler.py`, `test_models.py`) - that's fine.
 
 ### Step 1.5: Verify Structure
 
@@ -243,7 +243,7 @@ Expected structure:
 └── {plugin_name_snake}/          # Inner (snake_case)
     ├── CANVAS_MANIFEST.json
     ├── README.md
-    └── protocols/
+    └── handlers/
 ```
 
 **If any errors appear, investigate before proceeding.** Do NOT continue with implementation until the structure is correct.
@@ -254,11 +254,11 @@ Read the **plugin-patterns skill** and match the spec to a pattern:
 
 | Spec says... | Pattern | Handlers |
 |--------------|---------|----------|
-| Single event → alert/task | Single Handler | 1 BaseProtocol |
+| Single event → alert/task | Single Handler | 1 BaseHandler |
 | External webhook | Single Handler | 1 SimpleAPI |
-| Questionnaire processing | Single Handler | 1 BaseProtocol |
+| Questionnaire processing | Single Handler | 1 BaseHandler |
 | Scheduled/periodic | Single Handler | 1 CronTask |
-| Multiple events | Multi-Handler | 2-5 BaseProtocol |
+| Multiple events | Multi-Handler | 2-5 BaseHandler |
 | Interactive UI | Application | Application + SimpleAPI |
 | LLM/AI processing | LLM-Integrated | Multiple + llms/ |
 
@@ -266,7 +266,7 @@ Read the **plugin-patterns skill** and match the spec to a pattern:
 
 **Edit the files created by `canvas init` - do NOT create new files unless and until necessary.**
 
-1. **Edit the protocol handler** created by `canvas init` (typically `protocols/my_protocol.py`)
+1. **Edit the handler** created by `canvas init` (typically `handlers/my_handler.py`)
 2. **Use the canvas-sdk skill** to look up:
    - Exact EventType enum values
    - Effect class parameters
@@ -456,7 +456,7 @@ When invoked to **update an existing plugin** (not create a new one), follow thi
 Read and summarize the existing plugin:
 
 1. Read the `CANVAS_MANIFEST.json` to get name, version, components, secrets
-2. Read all handler files (protocols/, applications/, api/)
+2. Read all handler files (handlers/, applications/, api/)
 3. Read tests
 4. Read `plugin-spec.md` from `.cpa-workflow-artifacts/` if it exists
 

--- a/canvas-plugin-assistant/commands/coverage.md
+++ b/canvas-plugin-assistant/commands/coverage.md
@@ -106,7 +106,7 @@ If the user just wants a quick summary, show:
 ```
 Coverage: 87% (target: 90%)
 Files needing attention:
-  - protocols/handler.py: 82% (lines 34-38, 67)
+  - handlers/handler.py: 82% (lines 34-38, 67)
   - api/routes.py: 91% (line 23)
 ```
 

--- a/canvas-plugin-assistant/commands/new-plugin.md
+++ b/canvas-plugin-assistant/commands/new-plugin.md
@@ -128,7 +128,7 @@ $CPA_WORKSPACE_DIR/
     └── {plugin_name_snake}/          # Snake_case inner directory
         ├── CANVAS_MANIFEST.json
         ├── README.md
-        └── protocols/
+        └── handlers/
 ```
 
 #### Step 4: Verify Project Structure
@@ -154,7 +154,7 @@ $CPA_WORKSPACE_DIR/
     └── {plugin_name_snake}/          # Inner (snake_case)
         ├── CANVAS_MANIFEST.json
         ├── README.md
-        └── protocols/
+        └── handlers/
 ```
 
 **If any checks fail:** Report errors to the user and investigate before proceeding.

--- a/canvas-plugin-assistant/commands/wrap-up.md
+++ b/canvas-plugin-assistant/commands/wrap-up.md
@@ -183,7 +183,7 @@ Check that all test files test code that still exists:
 - Remove `test_models.py` if it's just scaffolding
 
 **Common dead code from scaffolding:**
-- `protocols/my_protocol.py` - default placeholder if you renamed your protocol
+- `handlers/my_handler.py` - default placeholder if you renamed your handler
 - `test_models.py` - often unused scaffolding
 - Unused effect imports (e.g., `AddTask` if you only use `AddBannerAlert`)
 - Empty or stub methods that were never implemented

--- a/canvas-plugin-assistant/skills/canvas-sdk/SKILL.md
+++ b/canvas-plugin-assistant/skills/canvas-sdk/SKILL.md
@@ -14,14 +14,14 @@ Use this skill when you need information about:
 - Event types and their context structures
 - Effect types and their payloads
 - Data models (Patient, Condition, Medication, etc.)
-- Handler types (BaseProtocol, SimpleAPI, Application, CronTask)
+- Handler types (BaseHandler, SimpleAPI, Application, CronTask)
 - Canvas CLI commands
 - Plugin manifest structure
 
 ## Key Documentation Sections
 
 ### Handlers
-- **BaseProtocol**: Event-driven handlers responding to Canvas events
+- **BaseHandler**: Event-driven handlers responding to Canvas events
 - **SimpleAPI**: HTTP endpoints and WebSocket handlers
 - **Application**: UI applications launched from the app drawer
 - **CronTask**: Scheduled task execution

--- a/canvas-plugin-assistant/skills/custom-data-patterns/custom_data_context.txt
+++ b/canvas-plugin-assistant/skills/custom-data-patterns/custom_data_context.txt
@@ -528,7 +528,7 @@ class CareTaskService:
             )
         return None
 
-# protocols/on_lab_result.py
+# handlers/on_lab_result.py
 class OnLabResult(BaseHandler):
     RESPONDS_TO = EventType.Name(EventType.LAB_REPORT__POST_UPDATE)
 
@@ -752,7 +752,7 @@ This does **not** apply to ModelExtension proxy classes (e.g., `CustomPatient(Pa
 my_plugin/
 ├── CANVAS_MANIFEST.json
 ├── models.py              # ← WRONG: migrations will not be applied
-├── protocols/
+├── handlers/
 │   └── my_handler.py
 └── tests/
 ```
@@ -775,7 +775,7 @@ my_plugin/
 ├── models/
 │   ├── __init__.py        # re-exports model classes
 │   └── task_log.py        # one model per file (recommended)
-├── protocols/
+├── handlers/
 │   └── my_handler.py
 └── tests/
 ```

--- a/canvas-plugin-assistant/skills/database-performance/performance_context.txt
+++ b/canvas-plugin-assistant/skills/database-performance/performance_context.txt
@@ -294,10 +294,10 @@ When reviewing, report findings as:
 
 | Severity | Issue | Location | Recommendation |
 |----------|-------|----------|----------------|
-| HIGH | N+1 query in patient loop | protocols/handler.py:45 | Add prefetch_related('conditions') |
-| HIGH | Query inside for loop | protocols/handler.py:67 | Move query outside loop, use filter(id__in=) |
+| HIGH | N+1 query in patient loop | handlers/handler.py:45 | Add prefetch_related('conditions') |
+| HIGH | Query inside for loop | handlers/handler.py:67 | Move query outside loop, use filter(id__in=) |
 | MEDIUM | Missing select_related | api/routes.py:23 | Add select_related('patient') |
-| LOW | Fetching all fields | protocols/handler.py:12 | Consider .only() for needed fields |
+| LOW | Fetching all fields | handlers/handler.py:12 | Consider .only() for needed fields |
 
 ### Query Analysis
 

--- a/canvas-plugin-assistant/skills/fhir-api-client-security/fhir_client_context.txt
+++ b/canvas-plugin-assistant/skills/fhir-api-client-security/fhir_client_context.txt
@@ -361,7 +361,7 @@ When reviewing, report findings as:
 |----------|-------|----------|----------------|
 | HIGH | Admin token in patient portal | api/portal.py:45 | Use SMART launch patient-scoped token |
 | HIGH | Over-scoped: user/*.* | manifest.json | Reduce to specific resources needed |
-| MEDIUM | Token logged | protocols/sync.py:23 | Remove token from log statement |
+| MEDIUM | Token logged | handlers/sync.py:23 | Remove token from log statement |
 | LOW | Token existence not checked | api/fhir.py:12 | Add validation before use |
 
 ### Summary

--- a/canvas-plugin-assistant/skills/testing/SKILL.md
+++ b/canvas-plugin-assistant/skills/testing/SKILL.md
@@ -28,9 +28,9 @@ my-plugin-name/                       # Container folder (kebab-case)
 ├── pyproject.toml                    # Container level
 ├── tests/                            # Container level - NOT inside inner folder!
 │   ├── conftest.py
-│   ├── protocols/
-│   │   ├── test_vitals_handler.py    # mirrors inner/protocols/vitals_handler.py
-│   │   └── test_lab_handler.py       # mirrors inner/protocols/lab_handler.py
+│   ├── handlers/
+│   │   ├── test_vitals_handler.py    # mirrors inner/handlers/vitals_handler.py
+│   │   └── test_lab_handler.py       # mirrors inner/handlers/lab_handler.py
 │   ├── api/
 │   │   └── test_routes.py            # mirrors inner/api/routes.py
 │   └── helpers/
@@ -38,7 +38,7 @@ my-plugin-name/                       # Container folder (kebab-case)
 └── my_plugin_name/                   # Inner folder (snake_case)
     ├── CANVAS_MANIFEST.json
     ├── README.md
-    ├── protocols/
+    ├── handlers/
     │   ├── vitals_handler.py
     │   └── lab_handler.py
     ├── api/
@@ -56,7 +56,7 @@ my-plugin-name/                       # Container folder (kebab-case)
 ```
 my-plugin-name/
 └── my_plugin_name/
-    ├── protocols/
+    ├── handlers/
     │   └── handler.py
     └── tests/                        # WRONG - tests inside inner folder!
         └── test_handler.py
@@ -71,7 +71,7 @@ mv my_plugin_name/tests ./tests
 
 - Each source file gets exactly ONE test file
 - Test file name = `test_` + source file name
-- Example: `protocols/handler.py` → `tests/protocols/test_handler.py`
+- Example: `handlers/handler.py` → `tests/handlers/test_handler.py`
 
 ### 3. Use Mocks for Isolation
 

--- a/canvas-plugin-assistant/skills/testing/testing_context.txt
+++ b/canvas-plugin-assistant/skills/testing/testing_context.txt
@@ -102,7 +102,7 @@ def test_high_bp(mock_event):
 ```
 plugin_name/
 ├── plugin_name/
-│   ├── protocols/
+│   ├── handlers/
 │   │   ├── vitals_handler.py
 │   │   └── lab_handler.py
 │   ├── api/
@@ -113,7 +113,7 @@ plugin_name/
 ├── tests/
 │   ├── __init__.py
 │   ├── conftest.py                   # Shared fixtures only
-│   ├── protocols/
+│   ├── handlers/
 │   │   ├── __init__.py
 │   │   ├── test_vitals_handler.py    # tests vitals_handler.py
 │   │   └── test_lab_handler.py       # tests lab_handler.py
@@ -205,7 +205,7 @@ def test_handler_with_patient(mock_event, mock_patient):
         mock_objects.get.return_value = mock_patient
 
         # Test handler logic
-        handler = MyProtocol()
+        handler = MyHandler()
         handler.event = mock_event
         effects = handler.compute()
 
@@ -241,7 +241,7 @@ def test_bad_example(mock_event, mock_patient):
     with patch("canvas_sdk.v1.data.patient.Patient.objects") as mock_objects:
         mock_objects.get.return_value = mock_patient
 
-        handler = MyProtocol()
+        handler = MyHandler()
         handler.event = mock_event
         effects = handler.compute()
 
@@ -253,7 +253,7 @@ def test_good_example(mock_event, mock_patient):
     with patch("canvas_sdk.v1.data.patient.Patient.objects") as mock_objects:
         mock_objects.get.return_value = mock_patient
 
-        handler = MyProtocol()
+        handler = MyHandler()
         handler.event = mock_event
         effects = handler.compute()
 
@@ -689,7 +689,7 @@ uv run pytest --cov=plugin_name --cov-fail-under=90  --cov-branch
 Name                              Stmts   Miss  Cover   Missing
 ---------------------------------------------------------------
 plugin_name/__init__.py               0      0   100%
-plugin_name/protocols/handler.py     45      5    89%   34-38
+plugin_name/handlers/handler.py     45      5    89%   34-38
 plugin_name/api/routes.py            32      2    94%   67, 89
 ---------------------------------------------------------------
 TOTAL                                77      7    91%
@@ -734,7 +734,7 @@ def test_missing_patient_context(self, mock_event):
     """Cover lines 34-38: missing patient handling."""
     mock_event.context = {}  # No patient in context
 
-    handler = MyProtocol()
+    handler = MyHandler()
     handler.event = mock_event
     effects = handler.compute()
 
@@ -821,7 +821,7 @@ When reporting coverage results:
 
 | File | Coverage | Missing Lines |
 |------|----------|---------------|
-| protocols/handler.py | 89% | 34-38 |
+| handlers/handler.py | 89% | 34-38 |
 | api/routes.py | 94% | 67, 89 |
 
 ### Recommended Tests to Add


### PR DESCRIPTION
## Summary

Follow-up to #80 (and to [this review comment](https://github.com/canvas-medical/coding-agents/pull/80#issuecomment-4412686127)). That PR migrated `plugin-patterns/patterns_context.txt` to the current SDK terminology — `BaseHandler` and `handlers/` — but left the same legacy terms scattered across other agent, command, and skill files. As a result, even after #80, a fresh CPA session would still pick up `protocols/`, `BaseProtocol`, and `MyProtocol` examples from the surrounding context and reintroduce them into newly scaffolded plugins.

This PR finishes the rename across the rest of the in-tree files.

## Changes

- `agents/plugin-brainstorm.md` — placeholder file path, expected-structure tree, pattern-match table, "edit the protocol handler" step, and the update-mode file enumeration.
- `commands/new-plugin.md` — both canonical project trees.
- `commands/wrap-up.md` — scaffolding cleanup bullet.
- `commands/coverage.md` — sample report path.
- `skills/testing/SKILL.md` — canonical tree, anti-pattern ("WRONG") tree, and the "Example:" line.
- `skills/testing/testing_context.txt` — directory tree, four `MyProtocol()` instantiations, coverage report path, coverage table row.
- `skills/database-performance/performance_context.txt` — three rows in the findings table.
- `skills/fhir-api-client-security/fhir_client_context.txt` — one row in the findings table.
- `skills/custom-data-patterns/custom_data_context.txt` — file-header comment, "BAD" tree, "GOOD" tree.
- `skills/canvas-sdk/SKILL.md` — `BaseProtocol` mentioned twice as a handler type.

No behavior change — documentation only.

## Deliberately out of scope

- **`evals/case_001/` and `evals/case_003/`** — these are fixture plugins that exercise the eval harness against realistic plugin code. The legacy `from canvas_sdk.protocols import BaseProtocol` form still works at runtime, and changing fixtures could mask regressions in the eval signal.
- **`skills/canvas-sdk/coding_agent_context.txt`** — this file is generated from the public SDK documentation at https://docs.canvasmedical.com. Editing it locally would be undone on the next sync. The upstream fix needs to land in `canvas-medical/documentation` first (filed separately).
- **`skills/fhir-api-client-development/fhir_client_context.txt:46512`** — `from canvas_sdk.protocols.clinical_quality_measure import ClinicalQualityMeasure`. This is a true clinical-protocol namespace; the word `protocols` is correct here.

## Test plan

- [x] `grep -rEn "BaseProtocol|protocols/|MyProtocol|my_protocol\.py" canvas-plugin-assistant/` returns only the three out-of-scope buckets above.
- [ ] Reviewer: skim the diff for any stale prose I missed, and confirm none of the surrounding context lost meaning.
