### PR TITLE
add context for NoteApplication and Custom Chart Summary Sections

### DIFF
--- a/canvas-plugin-assistant/agents/plugin-brainstorm.md
+++ b/canvas-plugin-assistant/agents/plugin-brainstorm.md
@@ -261,6 +261,36 @@ Read the **plugin-patterns skill** and match the spec to a pattern:
 | Multiple events | Multi-Handler | 2-5 BaseHandler |
 | Interactive UI | Application | Application + SimpleAPI |
 | LLM/AI processing | LLM-Integrated | Multiple + llms/ |
+| Custom chart summary section | Chart Summary Section | `PatientChartSummaryCustomSectionHandler` + `PatientChartSummaryConfiguration` BaseHandler (+ optional WebSocketAPI for real-time, see Step 2.5) |
+
+### Step 2.5: Real-time Decision (Chart Summary Sections only)
+
+**Only run this step if the spec describes a custom chart summary section** (anything served via `PatientChartSummaryCustomSectionHandler`).
+
+Before scaffolding, ask the user whether the section needs to refresh while the chart is open:
+
+```json
+{
+  "questions": [
+    {
+      "question": "Should this chart summary section update in real time when the underlying data changes?",
+      "header": "Real-time",
+      "options": [
+        {"label": "Yes — push live updates", "description": "Re-render when relevant events fire (e.g. a new order, a webhook arrives). Requires WebSocketAPI + Broadcast."},
+        {"label": "No — render once per chart load", "description": "Section content is fetched only when Canvas first requests it; user must reload the chart to see changes."}
+      ],
+      "multiSelect": false
+    }
+  ]
+}
+```
+
+**If the user picks "Yes":**
+- Add a `WebSocketAPI` handler and a broadcaster `BaseHandler` to the spec's component list.
+- **Patient-scope the channel name.** The channel string MUST include the patient id (e.g. `chart-summary-{plugin_name_snake}-{patient_id}`). Never broadcast on a global channel — it leaks PHI across charts and causes spurious re-renders for every connected client.
+- Use the canvas-sdk skill's "Real-Time Updates for Custom Sections" page for the canonical implementation (broadcaster pattern, WebSocket auth, template subscription).
+
+**If the user picks "No":** scaffold a plain `PatientChartSummaryCustomSectionHandler` with no WebSocket plumbing.
 
 ### Step 3: Implement
 

--- a/canvas-plugin-assistant/skills/canvas-sdk/SKILL.md
+++ b/canvas-plugin-assistant/skills/canvas-sdk/SKILL.md
@@ -18,12 +18,40 @@ Use this skill when you need information about:
 - Canvas CLI commands
 - Plugin manifest structure
 
+## Terminology / Aliases
+
+Users describe Canvas surfaces with different names. Map them to SDK classes before
+deciding which handler to scaffold:
+
+- **"Note Application", "NoteApplication", "Charting app", "Charting application", "note tab", "tab inside a note"** → an embedded application scoped to a note. Implement with `NoteApplication` (subclass of `EmbeddedApplication`, with `SCOPE = ApplicationScope.NOTE` preset). Located in `canvas_sdk.handlers.application`.
+- **"Embedded app", "embedded application"** → `EmbeddedApplication` directly. Use this when the scope is something other than note, or when the user wants to set `SCOPE` explicitly.
+- **"Full chart app", "chart tab"** → an `Application` registered with `"scope": "full_chart"` in `CANVAS_MANIFEST.json` (appears alongside the default "Chart" and "Profile" tabs).
+- **"App drawer application"** → a plain `Application` launched from the app drawer.
+
+When a user says "Charting app" or "NoteApplication", do not ask them to clarify — assume they mean a note-scoped embedded application (`NoteApplication`) unless they describe behavior that doesn't fit (e.g. "appears at the top of the chart" → full_chart scope).
+
+### Note Application templates: always auto-resize
+
+Every HTML template rendered by a `NoteApplication` must wire up the Canvas `RESIZE` message pattern so the iframe grows to fit its content instead of showing its own scrollbar inside the note. Apply this by default — do not ask the user to confirm. Only omit it if the user explicitly says they want a fixed-height iframe with its own scroll.
+
+The canonical pattern (full snippet in `coding_agent_context.txt`, under "Auto-resizing the Note Application iframe"):
+- `html, body { overflow: hidden; margin: 0; padding: 0; }`
+- Listen for `INIT_CHANNEL` → grab the `MessagePort`
+- Post `{ type: 'RESIZE', height: document.body.offsetHeight }` on connect and on every `ResizeObserver` tick
+
+### Custom chart summary sections: always ask about real-time
+
+When building a custom patient chart summary section (`PatientChartSummaryCustomSectionHandler`), **ask the user whether the section needs real-time updates** before scaffolding. If yes, implement it with a `WebSocketAPI` + `Broadcast` from a `BaseHandler` listening for the relevant Canvas events.
+
+**The WebSocket channel name MUST include the patient id** (e.g. `chart-summary-{plugin_name}-{patient_id}`). Never broadcast on a global channel — it leaks updates across patient charts and causes every connected client to re-render on every event. Full pattern + example in `coding_agent_context.txt`, under "Real-Time Updates for Custom Sections".
+
 ## Key Documentation Sections
 
 ### Handlers
 - **BaseHandler**: Event-driven handlers responding to Canvas events
 - **SimpleAPI**: HTTP endpoints and WebSocket handlers
 - **Application**: UI applications launched from the app drawer
+- **EmbeddedApplication / NoteApplication**: Embedded UI shown inside the chart or note (see Terminology above)
 - **CronTask**: Scheduled task execution
 - **ActionButton**: UI buttons in notes and patient headers
 

--- a/canvas-plugin-assistant/skills/canvas-sdk/coding_agent_context.txt
+++ b/canvas-plugin-assistant/skills/canvas-sdk/coding_agent_context.txt
@@ -37169,7 +37169,8 @@ Applications with the `full_chart` scope appear as navigation tabs at the top of
       "scope": "full_chart"
     }
     ```
-##  Note Applications 
+##  Note Applications
+> **Aliases:** Users may call these "Charting apps", "Charting applications", "note tabs", or refer to them generically as "EmbeddedApplication" — they all mean a note-scoped embedded application. `NoteApplication` is the concrete class to use (it is a thin subclass of `EmbeddedApplication` that presets `SCOPE = ApplicationScope.NOTE`).
 Note Applications appear as tabs within a patient's note, allowing you to embed custom interfaces directly in the clinical documentation workflow.
 ###  Implementing a Note Application 
 To create a Note Application, your handler class should inherit from `NoteApplication` and define two required class attributes:
@@ -37199,7 +37200,49 @@ Your class must implement the `on_open()` method, which is called when the user 
             ).apply()
     ```
 ![note applications](/assets/images/note-application-tabs.png)
-###  Context and Event Data 
+###  Auto-resizing the Note Application iframe
+**REQUIRED for all Note Application HTML templates unless the user explicitly opts out.** Note Applications render inside an iframe whose default height is small. Without auto-resize, content overflows and the iframe shows its own scrollbar inside the note — duplicating the note's scroll and making the UX feel broken.
+
+To prevent this, every Note Application template must:
+1. Hide the iframe's own scroll with `overflow: hidden` on `html`/`body`.
+2. Listen for the `INIT_CHANNEL` message from Canvas to obtain a `MessagePort`.
+3. Post `{ type: 'RESIZE', height }` (and optionally `width`) through the port whenever the content size changes, using a `ResizeObserver` on `document.body`.
+4. Send the initial size as soon as the port is received, so the iframe sizes correctly on first paint.
+
+Canonical template snippet (adapted from `canvas-plugins/dev/example_chart_app/templates/custom-ui.html`):
+    ```html
+    <style>
+      html, body { margin: 0; padding: 0; overflow: hidden; }
+      body { box-sizing: border-box; }
+    </style>
+    <script>
+      let messagePort = null;
+
+      function sendHeight() {
+        if (!messagePort) return;
+        messagePort.postMessage({
+          type: 'RESIZE',
+          height: document.body.offsetHeight,
+          width: document.body.offsetWidth,
+        });
+      }
+
+      window.addEventListener('message', (event) => {
+        if (event.data?.type === 'INIT_CHANNEL' && event.ports?.[0]) {
+          messagePort = event.ports[0];
+          messagePort.start();
+          sendHeight();  // initial size — do not debounce
+        }
+      });
+
+      window.addEventListener('DOMContentLoaded', () => {
+        new ResizeObserver(sendHeight).observe(document.body);
+      });
+    </script>
+    ```
+> **Only skip this pattern if the user explicitly says they want a fixed-height iframe with its own scroll.** Do not ask them to confirm — apply this pattern by default for every Note Application template you generate.
+
+###  Context and Event Data
 Both `on_open()` and `handle()` have access to context data through `self.event.context`:
 Key | Description  
 ---|---  
@@ -38593,6 +38636,108 @@ The following example shows a complete plugin with a custom section that display
       }
     }
     ```
+##  Real-Time Updates for Custom Sections
+`PatientChartSummaryCustomSectionHandler.handle()` only runs when Canvas first requests the section. If the underlying data changes while the chart is open (a new order, a webhook payload, a command being committed, etc.) the section will be stale until the user reloads the chart.
+
+> **Always ask the user whether the custom section needs real-time updates** before implementing one. If they answer yes, use the WebSocket pattern below. If they answer no, just render the static section and stop — do not add WebSocket plumbing speculatively.
+
+###  Pattern: Patient-scoped WebSocket
+When real-time is required, the canonical pattern is:
+  1. **Define a `WebSocketAPI`** on a channel whose name includes the patient id (e.g. `chart-summary-{plugin_name}-{patient_id}`). Authenticate against the logged-in staff user — see [WebSocket API](/sdk/handlers-simple-api-websocket/).
+  2. **Broadcast on data-change events** from a `BaseHandler` that listens to the relevant Canvas events. The `Broadcast` effect must target the channel for the affected patient only.
+  3. **Subscribe from the section template.** Render the patient id into the HTML at server-side render time, then open the WebSocket from JavaScript and re-fetch / re-render on each message.
+
+> **⚠️ Always include the patient id in the channel name.** Never broadcast on a global channel like `chart-summary-updates`. Reasons:
+> - **PHI isolation:** providers may have other patient charts open. A global broadcast would leak updates across patients.
+> - **Performance:** every connected client would receive every event; the iframe would re-render constantly.
+> - **HIPAA-aligned minimum disclosure:** only the chart for the affected patient should receive the signal.
+
+###  Example: vitals section that refreshes when new vitals are committed
+**`handlers/vitals_section.py`** — section handler renders the template with the patient id and a cache-bust token:
+    ```python
+    from datetime import datetime, timezone
+    from canvas_sdk.effects import Effect
+    from canvas_sdk.effects.patient_chart_summary_custom_section import PatientChartSummaryCustomSection
+    from canvas_sdk.handlers.patient_chart_summary_custom_section_handler import (
+        PatientChartSummaryCustomSectionHandler,
+    )
+    from canvas_sdk.templates import render_to_string
+
+    _CACHE_BUST = str(int(datetime.now(timezone.utc).timestamp()))
+
+    class VitalsSectionHandler(PatientChartSummaryCustomSectionHandler):
+        SECTION_KEY = "live_vitals"
+        def handle(self) -> list[Effect]:
+            patient_id = self.target
+            return [
+                PatientChartSummaryCustomSection(
+                    content=render_to_string(
+                        "templates/live_vitals.html",
+                        {"patient_id": patient_id, "cache_bust": _CACHE_BUST},
+                    ),
+                    icon="❤️",
+                ).apply()
+            ]
+    ```
+**`handlers/vitals_ws.py`** — WebSocketAPI authenticates the connection. The channel name carries the patient id, so authorisation can be enforced per patient if needed.
+    ```python
+    from canvas_sdk.handlers.simple_api.websocket import WebSocketAPI
+
+    class VitalsWebSocket(WebSocketAPI):
+        def authenticate(self) -> bool:
+            user = self.websocket.logged_in_user
+            return bool(user) and user.get("type") == "Staff"
+    ```
+**`handlers/vitals_broadcaster.py`** — BaseHandler listens for vitals commits and broadcasts to that patient's channel only:
+    ```python
+    from canvas_sdk.effects import Effect
+    from canvas_sdk.effects.simple_api import Broadcast
+    from canvas_sdk.events import EventType
+    from canvas_sdk.handlers import BaseHandler
+
+    class VitalsBroadcaster(BaseHandler):
+        RESPONDS_TO = [EventType.Name(EventType.VITALS_COMMAND__POST_COMMIT)]
+        def compute(self) -> list[Effect]:
+            patient_id = self.event.context.get("patient", {}).get("id")
+            if not patient_id:
+                return []
+            return [
+                Broadcast(
+                    channel=f"chart-summary-my_plugin-{patient_id}",
+                    message={"type": "vitals_updated"},
+                ).apply()
+            ]
+    ```
+**`templates/live_vitals.html`** — subscribes to the patient-specific channel and refreshes on message:
+    ```html
+    <div id="vitals-root">Loading…</div>
+    <script>
+      const patientId = "{{ patient_id }}";
+      const channel = `chart-summary-my_plugin-${patientId}`;
+      const wsUrl = `wss://${location.host}/plugin-io/ws/my_plugin/${channel}/`;
+
+      function connect() {
+        const ws = new WebSocket(wsUrl);
+        ws.onmessage = () => refresh();
+        ws.onclose = () => setTimeout(connect, 2000);  // gentle reconnect
+      }
+      function refresh() {
+        fetch(`/plugin-io/api/my_plugin/vitals/${patientId}?v={{ cache_bust }}`)
+          .then(r => r.text())
+          .then(html => { document.getElementById("vitals-root").innerHTML = html; });
+      }
+      refresh();
+      connect();
+    </script>
+    ```
+**Manifest entries** — register the section handler, the configuration handler, the WebSocketAPI, and the BaseHandler in `CANVAS_MANIFEST.json` under `components.handlers`. The WebSocket channel name format is plugin-defined; standardise on `<purpose>-<plugin_name>-<patient_id>` to make it obvious that broadcasts are patient-scoped.
+
+###  Checklist for real-time chart summary sections
+  - [ ] Asked the user whether real-time is required (don't assume).
+  - [ ] Channel name includes the patient id — verified by grepping the broadcaster and the template for the same template variable.
+  - [ ] `Broadcast` is only called when `patient_id` is present in the event context.
+  - [ ] `WebSocketAPI.authenticate()` rejects unauthenticated/external connections unless an API key flow is intentionally exposed.
+  - [ ] Template reconnects on `onclose` so the section stays live across transient network drops.
 ----- END PAGE https://docs.canvasmedical.com/sdk/patient-chart-summary-custom-section-handler/
 
 


### PR DESCRIPTION
This pull request enhances the documentation and guidance for building Canvas plugins, focusing on clarifying terminology, enforcing best practices for Note Applications, and introducing a robust pattern for real-time updates in custom chart summary sections. The changes ensure that plugin authors consistently apply required UI behaviors and security measures, and that the assistant reliably asks users about real-time requirements before scaffolding chart summary sections.

**Key improvements include:**

### Terminology and Handler Mapping

- Added a terminology section to clarify user aliases for Canvas surfaces (e.g., "Charting app", "NoteApplication", "Embedded app") and mapped them to their corresponding SDK handler classes, reducing ambiguity during plugin scaffolding. [[1]](diffhunk://#diff-a3c98b65446e6fffd88273b1e606a1d0e6bf5c90166b89c82ba88e8cc797a6ffR21-R54) [[2]](diffhunk://#diff-4c23052cb4b2aa2d22d6239f38f66243d1ffa18c3c7c73f1c038f52fc01f6a04R37173)

### Note Application Best Practices

- Enforced that all Note Application HTML templates must implement the auto-resizing iframe pattern by default (unless the user explicitly opts out), including a canonical code snippet and explanation for why this is required for proper UX. [[1]](diffhunk://#diff-a3c98b65446e6fffd88273b1e606a1d0e6bf5c90166b89c82ba88e8cc797a6ffR21-R54) [[2]](diffhunk://#diff-4c23052cb4b2aa2d22d6239f38f66243d1ffa18c3c7c73f1c038f52fc01f6a04R37203-R37244)
- Updated documentation to reflect that "Charting app" and similar terms should default to `NoteApplication` unless the user's description clearly indicates otherwise.

### Real-Time Updates for Chart Summary Sections

- Introduced a decision step requiring the assistant to always ask users whether custom chart summary sections need real-time updates before scaffolding, with clear instructions for both "yes" and "no" answers. [[1]](diffhunk://#diff-143ffb12110fabb32311a2b6cb7a3dbe1a9ce2cb007a0824645428d1113222a3R264-R293) [[2]](diffhunk://#diff-a3c98b65446e6fffd88273b1e606a1d0e6bf5c90166b89c82ba88e8cc797a6ffR21-R54)
- Documented the canonical, secure pattern for implementing real-time updates: patient-scoped WebSocket channels, authenticated connections, and targeted broadcasts, with a full working example and a checklist to prevent PHI leakage or performance issues. [[1]](diffhunk://#diff-4c23052cb4b2aa2d22d6239f38f66243d1ffa18c3c7c73f1c038f52fc01f6a04R38639-R38740) [[2]](diffhunk://#diff-143ffb12110fabb32311a2b6cb7a3dbe1a9ce2cb007a0824645428d1113222a3R264-R293) [[3]](diffhunk://#diff-a3c98b65446e6fffd88273b1e606a1d0e6bf5c90166b89c82ba88e8cc797a6ffR21-R54)

These changes improve both the reliability and security of generated plugins, and make the assistant's behavior more predictable and aligned with Canvas best practices.