### PR TITLE
canvas-sdk skill: force grounding for SDK questions

### DIFF
--- a/canvas-plugin-assistant/skills/canvas-sdk/SKILL.md
+++ b/canvas-plugin-assistant/skills/canvas-sdk/SKILL.md
@@ -1,22 +1,36 @@
 ---
 name: canvas-sdk
-description: Canvas SDK reference and documentation access for Canvas platform capabilities, API usage, implementation patterns, and testing
+description: Canvas SDK reference and documentation. Use whenever a question, claim, or piece of code touches Canvas SDK capabilities, API usage, implementation patterns, or testing — including quick conversational questions ("how do I ingest ADTs?", "what's the import for X?", "does Canvas support Y?"). The bundled docs are the source of truth; do not answer Canvas SDK questions from memory.
 ---
 
 # Canvas SDK Reference
 
 This skill provides comprehensive documentation for the Canvas Medical SDK, enabling development of Canvas plugins.
 
+## Grounding Rule — Read Before Answering
+
+**Never answer a Canvas SDK question from memory.** Canvas's SDK surface (effects, events, data models, handlers, manifest fields, import paths) is Canvas-specific and changes often; the model's prior is frequently wrong or out of date. Confidently-wrong answers about Canvas APIs are worse than no answer.
+
+Before stating any specific class name, import path, effect/event name, field name, method, or supported value:
+1. Read `coding_agent_context.txt` from this skill's directory (see Usage below) and `grep`/search it for the relevant term.
+2. Base your answer on what the bundled docs actually say.
+3. **Cite the source doc page URL** (the `----- BEGIN PAGE https://docs.canvasmedical.com/...` line that contains the content) so the user can verify it — the same way a high-quality grounded answer always links its source.
+
+This applies to a one-line verbal question just as much as to code generation. If a question is even partially about an SDK capability and you have not yet consulted this skill in the current conversation, consult it first, then answer.
+
 ## When to Use This Skill
 
-Use this skill when you need information about:
+Use this skill whenever a question, claim, or piece of code involves — even in passing — any of:
 - Canvas SDK classes, methods, and APIs
 - Event types and their context structures
-- Effect types and their payloads
+- Effect types and their payloads (e.g. creating external events / ADT ingestion, banner alerts, tasks)
 - Data models (Patient, Condition, Medication, etc.)
 - Handler types (BaseHandler, SimpleAPI, Application, CronTask)
 - Canvas CLI commands
 - Plugin manifest structure
+- Whether Canvas "supports" some capability, and how it is modeled
+
+This includes short conversational questions, not just plugin-building work. Examples that REQUIRE consulting this skill before answering: "how do I ingest ADTs?", "what's the import path for the external event effect?", "what fields does X take?", "does Canvas have a built-in HL7 parser?". Do not answer any of these from memory.
 
 ## Terminology / Aliases
 
@@ -105,6 +119,7 @@ To use this skill:
 1. **Read `coding_agent_context.txt` from this skill's directory** - it already exists locally
 2. Search the file for specific class names, event types, or effect types
 3. Use the documentation to understand Canvas SDK capabilities
+4. **Cite the source doc page URL** in your answer (the `----- BEGIN PAGE https://docs.canvasmedical.com/...` URL whose section you used), so the answer is verifiable and grounded rather than asserted from memory
 
 The context file contains ~20000 lines of comprehensive SDK documentation including all handlers, events, effects, and data models.
 


### PR DESCRIPTION
## Why

A user asked CPA about ADT ingestion and got an answer that directly contradicted the (correct) answer navigator gave for the same question — [Slack thread](https://canvas-medical.slack.com/archives/C0B5AV3TGKE/p1779399493148379).

I traced it: the contradiction was **not** a stale or missing docs snapshot. CPA's `canvas-sdk` skill already bundles the `effect-external-event` page in `coding_agent_context.txt` — `CREATE_EXTERNAL_EVENT`, `from canvas_sdk.effects.external_event import ExternalEvent`, every field, every ADT code — and it matches both the live docs and navigator's answer line-for-line. The `Update Canvas documentation context [automated]` commits keep that snapshot fresh.

The correct content was sitting right there. CPA answered the question **without consulting the skill** and fell back on the model's prior, which invented a contradiction. Skill invocation is model-driven, so for a casual "how do I do ADTs?" the skill simply didn't get loaded. Navigator gets these right because grounding is an always-on instruction in its prompt; CPA had no rule forcing it to ground SDK answers.

## What changed

Hardens the `canvas-sdk` skill (no new hook — consistent with the recent move away from blind hooks) so it is consulted before answering any Canvas SDK question, including short conversational ones, and so answers cite their source:

- Broaden the frontmatter `description` to drive auto-invocation on quick verbal questions ("how do I ingest ADTs?", "what's the import for X?", "does Canvas support Y?"), not just plugin-building work.
- Add a **Grounding Rule — Read Before Answering** section: never answer Canvas SDK questions from memory; grep the bundled context first and cite the source doc page URL so the answer is verifiable.
- Expand **When to Use** with concrete must-ground examples (ADT ingestion via the external-event effect, import paths, capability questions).

## Scope / limits

This is the lighter, model-driven fix: it improves the odds the skill is invoked and makes grounding the explicit expected behavior, but it still relies on the model honoring the skill description. If we later want a hard guarantee, a `UserPromptSubmit` hook injecting the same directive every turn is the deterministic backstop — deliberately not included here to avoid reintroducing an always-on hook.