### PR TITLE
Expand database-performance skill beyond N+1 (memory, writes, exec limits)

### DIFF
--- a/canvas-plugin-assistant/commands/database-performance-review.md
+++ b/canvas-plugin-assistant/commands/database-performance-review.md
@@ -42,17 +42,34 @@ grep -rn "\.objects\." --include="*.py" .
 
 ### 2. Invoke Database Performance Skill
 
-Invoke the **database-performance** skill to analyze query patterns.
+Invoke the **database-performance** skill to analyze data-access patterns across **all four failure modes** — not just N+1.
+
+**Measure before you fix.** Query count is only one axis. Before proposing changes, identify the hot path (which endpoint/handler and how often it runs), then estimate **rows × row width per request** (memory) and **writes/effects per trigger** (amplification). Confirm the fix addresses the actual bottleneck — an oversized effect batch or a non-converging import is algorithmic and scaling workers/memory will not fix it.
 
 The skill will check for:
+
+*Read count (N+1):*
 - **N+1 query patterns**: Queries executed inside loops
 - **Missing `select_related()`**: Foreign key access without prefetching
 - **Missing `prefetch_related()`**: Reverse relation or many-to-many access without prefetching
-- **Unbounded queries**: `.all()` or `.filter()` without limits
 - **Inefficient filtering**: Filtering in Python instead of database
-- **Large queryset materialization**: `list()` wrapping unbounded querysets loads everything into memory
-- **Missing `.iterator()`**: Large table scans without `.iterator(chunk_size=N)` cache all rows
-- **Missing `.only()`**: Fetching all columns when only a few fields are used
+
+*Over-hydration / memory:*
+- **Large text/JSON blob columns loaded but unused**: `Note._body` and other `*_body`/`*_json`/`*_data`/`payload`/`content`/document fields can dwarf the rest of the row → `.defer(...)` them, or `.only(...)`/`.values(...)` the small fields you use. Often the single biggest per-row cost.
+- **`select_related` used only for an id**: joining a large relation (e.g. `note`) whose only downstream use is `.dbid`/`.id` → read the `<fk>_id` column instead
+- **Full-instance hydration on hot list endpoints**: use `.values()`/`.only()` projections
+- **Large queryset materialization / missing `.iterator()`**: `list()` wrapping or bare `.all()` iteration over large tables
+- **Cache/state accumulator**: a resumable or cron-driven job that stores all results-so-far in one cache entry or in-process list (read → concat → re-serialize each call) → persist only the cursor/metadata (`offset`, `total`, `complete`), process each page in place
+- **Unlocked serializer contract**: no `FIELDS` frozenset + test, so the card can silently regrow
+
+*Write amplification:*
+- **Redundant writes**: `.update()`/`.save()` in sync/webhook/reconcile paths with no content-hash change guard
+- **Unbounded reconcile**: "delete all + recreate all" not scoped to the changed window/day
+- **Non-converging / non-idempotent imports**: can re-create an already-imported record
+
+*Canvas execution limits:*
+- **Custom-data PK**: `Count("id")`/`order_by("id")` on a custom-data (SDK) model → use `dbid`
+- **Effect-batch ceiling**: a handler emitting effects proportional to an unbounded queryset → chunk via queue + cron (one batch must stay under the 64 MB gRPC limit)
 
 ---
 
@@ -94,6 +111,55 @@ grep -rn "\.objects\.all()\|\.objects\.filter(" --include="*.py" . | grep -v "\.
 
 Cross-reference `.only()` hits with actual field usage to confirm unnecessary columns are being fetched.
 
+**Over-hydration — large text/JSON blob columns loaded without .defer()/.only():**
+```bash
+grep -rn "_body\|_json\|_html\|_data\|payload\|\.content" --include="*.py" .
+```
+
+For each model that has a large blob column (notably `Note._body`), check whether the query paths that fetch that model actually read the blob. If not, flag it — the query should `.defer("_body", ...)`, `.only(...)` the small fields, or `.values(...)` when only scalars are needed. A blob column loaded across hundreds/thousands of rows is a memory blowout even at a perfect query count. Also check `select_related`/`prefetch_related` that pull a relation whose rows carry a blob column.
+
+**Cache/state accumulator (memory grows with total items, not per batch):**
+```bash
+grep -rn "cache.get\|cache.set\|json.loads\|json.dumps" --include="*.py" .
+```
+
+Look for a resumable/cron job that reads a cache blob, concatenates new items onto a stored list, and re-serializes the whole thing each call (e.g. `state["entries"] = state.get("entries", []) + new_rows`). That accumulates unbounded state and holds 2–3 copies at peak. Flag it — the job should persist only the cursor/metadata and process each page in place.
+
+**Over-hydration — select_related used only for an id:**
+```bash
+grep -rn "select_related(" --include="*.py" .
+```
+
+For each hit, check the downstream use of the joined relation. If the only access is `.dbid`/`.id` (e.g. `appt.note.dbid`), flag it — read the `<fk>_id` column (`appt.note_id`) instead so the large related row is never hydrated.
+
+**Custom-data PK — `id` used where the PK is `dbid`:**
+```bash
+grep -rn 'Count("id")\|order_by("id")\|values("id")\|F("id")' --include="*.py" .
+```
+
+For custom-data (SDK) models, `"id"` raises `FieldError` (PK is `dbid`). Cross-reference against models defined with the SDK base.
+
+**Write amplification — writes in sync/webhook/reconcile paths:**
+```bash
+grep -rn "\.update(\|\.save(\|\.delete(" --include="*.py" .
+```
+
+In inbound/webhook/sync/reconcile code, flag writes that run unconditionally on every delivery. Look for a content-hash / change guard before the write; flag "delete all + recreate all" that isn't bounded to the changed window.
+
+**Effect-batch ceiling — effects proportional to an unbounded queryset:**
+```bash
+grep -rn "for.*in.*\.objects" --include="*.py" . -A 8 | grep -E "\.apply\(|effects\.append|effects \+=|return effects"
+```
+
+Flag handlers that build an effect list by looping over all providers/patients/appointments and return it in one batch — chunk via queue + cron instead.
+
+**Tests that mock the ORM (hide field/query errors):**
+```bash
+grep -rn "patch(.*objects\|Mock().*objects\|MagicMock" --include="*.py" ./tests 2>/dev/null
+```
+
+A query/field change covered only by a mocked queryset is not real coverage — the mock never resolves field names, so `Count("id")`-style bugs pass in CI.
+
 ---
 
 ### 4. Generate Performance Report
@@ -114,15 +180,18 @@ Save report to `$WORKSPACE_DIR/.cpa-workflow-artifacts/db-performance-review-$TI
 
 ## Summary
 
-| Category | Status | Issues |
-|----------|--------|--------|
-| N+1 Query Patterns | ✅ Pass / ⚠️ X issues / N/A | ... |
-| select_related Usage | ✅ Pass / ⚠️ X issues / N/A | ... |
-| prefetch_related Usage | ✅ Pass / ⚠️ X issues / N/A | ... |
-| Query Bounds | ✅ Pass / ⚠️ X issues / N/A | ... |
-| Large Queryset Materialization | ✅ Pass / ⚠️ X issues / N/A | ... |
-| Missing .iterator() | ✅ Pass / ⚠️ X issues / N/A | ... |
-| Missing .only() | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Axis | Category | Status | Issues |
+|------|----------|--------|--------|
+| Read count | N+1 Query Patterns | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Read count | select_related / prefetch_related Usage | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Memory | Over-hydration (blob columns loaded / select_related for id only) | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Memory | Large queryset materialization / .iterator() / .only() | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Memory | Cache/state accumulator (cursor-only, no growing blob) | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Memory | Serializer contract locked | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Write | Redundant writes / content-hash guard | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Write | Bounded reconcile / idempotent sync | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Exec limit | Custom-data PK (dbid vs id) | ✅ Pass / ⚠️ X issues / N/A | ... |
+| Exec limit | Effect-batch ceiling (queue+cron chunking) | ✅ Pass / ⚠️ X issues / N/A | ... |
 
 ## Detailed Findings
 

--- a/canvas-plugin-assistant/skills/custom-data-patterns/SKILL.md
+++ b/canvas-plugin-assistant/skills/custom-data-patterns/SKILL.md
@@ -20,3 +20,5 @@ Invoke this skill **proactively** as soon as Custom Data is involved — don't w
 ## Quick Reference
 
 Reference the `custom_data_context.txt` file for detailed anti-patterns with BAD/GOOD examples.
+
+> **Custom-data models are keyed on `dbid`, not `id`.** Any query that references `"id"` on a `CustomModel` — `Count("id")`, `order_by("id")`, `values("id")`, `F("id")` — raises `FieldError: Cannot resolve keyword 'id' into field`. Use `dbid` (the primary key on the SDK base model). Tests that mock the queryset (`patch(...objects...)`) never resolve the real field name, so this bug passes CI and 500s against a live DB. See the **database-performance** skill (§"Canvas Execution Limits") for detection and the write-amplification/idempotency patterns that also apply to custom-data-backed sync.

--- a/canvas-plugin-assistant/skills/database-performance/SKILL.md
+++ b/canvas-plugin-assistant/skills/database-performance/SKILL.md
@@ -1,35 +1,64 @@
 ---
 name: database-performance
-description: Database query optimization for Canvas plugins - N+1 detection, prefetch_related, select_related
+description: Database performance for Canvas plugins - N+1 detection, over-hydration/memory, write amplification, and Canvas execution limits (effect-batch ceiling, dbid PK)
 ---
 
 # Database Performance Skill
 
-This skill provides database query optimization guidelines for Canvas plugins. Use it to identify N+1 query issues and optimize data access patterns using Django ORM best practices.
+This skill provides database performance guidelines for Canvas plugins. Query count (N+1) is only one failure mode. Real go-live incidents on Canvas instances have been caused just as often by **over-hydration/memory**, **write amplification**, **unbounded reconcile scope**, and **Canvas-specific execution limits** — none of which are fixed by adding `select_related`. Use this skill to diagnose across all four axes, not just N+1.
+
+## The four failure modes
+
+1. **Read count (N+1):** many small queries where one join/prefetch would do. Fix with `select_related` / `prefetch_related`.
+2. **Over-hydration / memory:** too few queries, but each pulls too much — wide rows × many rows, a large related row joined just to read one value, or a **large text/JSON blob column** (e.g. `Note._body`) loaded for every row when nothing reads it. A single blob column can dwarf the rest of the row, so this is often the biggest per-row cost. Fix by *not* loading what you don't use: `.defer()` blob columns, `.values()`/`.only()` projections, drop unneeded joins, trim serializers. A related non-query variant: **accumulating unbounded state across invocations** — a cron/backfill that keeps all results-so-far in one cache blob or in-process list (read → concat → re-serialize each call) grows with total items, not per-batch. Persist only the cursor/metadata. This whole axis is the one people miss because it *looks* optimized.
+3. **Write amplification:** redundant or cascading writes (re-saving unchanged rows; each write triggering a handler/external push). Fix with content-hash no-op guards, idempotency, and convergence.
+4. **Canvas execution limits:** the 64 MB gRPC effect-batch ceiling, effects applied only after the handler returns, and custom-data models keyed on `dbid` (not `id`). These are invisible to generic Django advice.
+
+## When more queries is BETTER
+
+Do **not** reflexively add `select_related`. Adding a join to a **large** relation (e.g. `Note`) that you only need one scalar from is an anti-pattern: it hydrates the whole row per result and drives memory. To read a related object's primary key, use the FK column that's already on the row (`appointment.note_id`), never `select_related("note").note.dbid`. Prefer more, narrower queries over one fat over-fetching join when the joined row is large and mostly unused.
+
+Likewise, do not load **large text/JSON blob columns** you don't use. `Note._body` and other `*_body`/`*_json`/`payload`/document fields can be far larger than every other field combined; pulling them across many rows is a memory blowout even at a perfect query count. Default to `.defer("_body", ...)` or `.only(...)` the small fields, or `.values(...)` when you only need scalars. See `performance_context.txt` §"Over-Hydration & Memory."
 
 ## When to Use This Skill
 
 Use this skill when:
 - Reviewing plugin code that queries Canvas data models
-- Identifying potential N+1 query problems
-- Optimizing loops that access related objects
-- Auditing database access patterns before deployment
+- Diagnosing memory growth / container memkills on a hot endpoint (hit on many page loads)
+- Reviewing sync / webhook / reconcile paths for redundant or runaway writes
+- Reviewing handlers that emit many effects, or that query custom-data (SDK) models
+- Auditing data access patterns before deployment
+
+## Diagnose before you grep
+
+The GTM performance PRs that landed all *measured first*, then attributed root cause. Before proposing fixes:
+- Identify the **hot path** (which endpoint/handler, how often it runs).
+- Estimate **rows × row width** per request (memory), and **writes/effects per trigger** (amplification), not just query count.
+- Confirm scaling workers/memory would actually help — an oversized effect batch or a non-converging import is algorithmic, and no amount of scaling fixes it.
 
 ## Quick Detection
 
-Search for these patterns that often indicate N+1 issues:
-
 ```bash
-# Loops accessing related objects
+# Loops accessing related objects (N+1)
 grep -rn "for.*in.*\.objects" --include="*.py" .
-grep -rn "\.filter\|\.get\|\.all" --include="*.py" .
+# select_related on a relation only used for its id (over-hydration)
+grep -rn "select_related(" --include="*.py" .
+# large text/JSON blob columns pulled without .defer()/.only() (over-hydration)
+grep -rn "_body\|_json\|_html\|payload\|\.content" --include="*.py" .
+# cache/state accumulators: full blob read+concat+re-serialize each run (memory)
+grep -rn "cache.get\|cache.set\|json.loads\|json.dumps" --include="*.py" .
+# Count/order_by("id") on custom-data models — FieldError (PK is dbid)
+grep -rn 'Count("id")\|order_by("id")\|Count(.id.)' --include="*.py" .
+# Writes in sync/webhook paths without a change guard (write amplification)
+grep -rn "\.update(\|\.save(" --include="*.py" .
 ```
 
 ## Performance Checklist
 
 Reference the `performance_context.txt` file for detailed patterns including:
-- N+1 query detection
-- `select_related()` for foreign keys
-- `prefetch_related()` for reverse relations and many-to-many
-- Common Canvas SDK data model relationships
-- Anti-patterns to avoid
+- N+1 query detection (`select_related` / `prefetch_related`)
+- Over-hydration & memory (drop unneeded joins, `.values()`/`.only()`, serializer contracts)
+- Write amplification & idempotency (content-hash no-op guards, convergence, cascades)
+- Canvas execution limits (`dbid` PK, 64 MB effect-batch ceiling, queue+cron chunking)
+- Bounding reconcile/sync work to what changed
+- Common Canvas SDK data model relationships and anti-patterns

--- a/canvas-plugin-assistant/skills/database-performance/performance_context.txt
+++ b/canvas-plugin-assistant/skills/database-performance/performance_context.txt
@@ -261,22 +261,243 @@ Combine `.only()` with `.iterator()` when you only need a few fields — this re
 
 ---
 
+## Over-Hydration & Memory
+
+N+1 is about the *number* of queries. Over-hydration is the opposite failure: too *few* queries, each pulling far too much. On a hot endpoint (one hit on nearly every page load), row_count × row_width is what drives per-request memory — and that is what causes container memkills, not query count. Real incident (a go-live instance with a large migrated dataset): a `/appointments` feed hydrated up to 3,000 `Appointment` rows per request with 6 `select_related` joins, producing ~80 MB single-request spikes and plugin-runner memkills. The fix was to *remove* a join and trim the serializer.
+
+### 1. Never load large text/JSON blob columns unless you actually use them
+
+Some columns hold large free-text or JSON blobs — the clinical `Note._body`, serialized payloads, cached JSON, HTML/document fields. A single such column can dwarf every other field on the row, so loading it across hundreds or thousands of rows is a memory blowout **even when the query count is perfect**. This is the same failure as over-hydrating a relation (the `Note.dbid` case below), one level down — at the *column* level. It is often the single biggest per-row memory cost, so treat it first.
+
+Two rules:
+- To read a related row's id, don't load the row at all — use the `<fk>_id` column (see #2 below).
+- When you need a model instance but not its blob field(s), exclude them with `.defer()`, or name only what you need with `.only()`. Django loads a deferred field lazily if something later touches it — so make sure nothing does, or you reintroduce an N+1.
+
+```python
+# BAD - loads the full Note body for every row just to show a heading + date
+notes = Note.objects.filter(patient_id=pid)          # SELECT * — includes _body
+for n in notes:
+    render(n.title, n.datetime_of_service)           # never touches the body
+
+# GOOD - never fetch the blob column
+notes = Note.objects.filter(patient_id=pid).defer("_body")
+# or, equivalently, name exactly the small fields you use:
+notes = Note.objects.filter(patient_id=pid).only("dbid", "title", "datetime_of_service")
+```
+
+Treat any `*_body`, `*_json`, `*_data`, `*_html`, `payload`, `content`, or document/blob field as "do not load unless required." If you only need a scalar off such a model, project it with `.values("dbid", "title", ...)` and skip model hydration entirely. The same caution applies to a `select_related`/`prefetch_related` that pulls a relation whose rows carry a blob column — add `.defer()` on the related fields or don't join at all.
+
+### 2. Do NOT `select_related` a large relation just to read its id
+
+This is the most important correction to the "always add select_related" reflex. A ForeignKey's own column already holds the related row's primary key — you never need to join the related table to read it.
+
+```python
+# BAD - joins and hydrates the ENTIRE Note row for every appointment,
+# solely to read the note's integer id. On a 3,000-row feed this is a memory driver.
+appointments = Appointment.objects.select_related("patient", "provider", "note")
+for appt in appointments:
+    note_id = appt.note.dbid          # forces the whole Note to be loaded
+
+# GOOD - read the FK column that is already on the appointment row.
+# note_id IS the Note's primary key; the large Note row is never joined or hydrated.
+appointments = Appointment.objects.select_related("patient", "provider")
+for appt in appointments:
+    note_id = appt.note_id            # no join, no Note hydration
+```
+
+Rule: **to read a related object's PK, use `<fk>_id`, not `select_related(<fk>).<fk>.dbid`.** Only `select_related` a relation when you actually read multiple fields off the related object per row. When the joined row is large and mostly unused, more/narrower queries beat one fat join.
+
+### 3. Trim serializers to exactly what the front end reads
+
+Fetching or emitting fields nobody uses is both a memory cost and a data-leak surface. Lock the read contract so it cannot silently regrow.
+
+```python
+# The exact keys the card emits — the front-end read contract. Kept explicit and
+# asserted in tests so the serializer can't silently grow extra fields (over-fetching /
+# leaking) or drop one the UI needs.
+CARD_FIELDS = frozenset({"id", "note_id", "start", "status", "patient_id", "patient_name", ...})
+
+def serialize_appointment(appt) -> dict:
+    return {"id": appt.dbid, "note_id": appt.note_id, ...}
+
+# In tests:
+def test_card_contract():
+    assert set(serialize_appointment(fake_appt())) == set(CARD_FIELDS)
+```
+
+### 4. Prefer `.values()` / `.only()` on read-heavy list endpoints
+
+If the endpoint returns a projection (not full model behavior), select only the columns you serialize. `.values("dbid", "note_id", "start_time", ...)` or `.only(...)` avoids hydrating full model instances for thousands of rows.
+
+---
+
+## Accumulating Unbounded State Across Invocations
+
+A memory failure mode that isn't a query at all, but shows up in the same investigations. A resumable/paginated job (typically a cron-driven scan or backfill) keeps all results-so-far in a **single cache entry** (e.g. Redis) or a single in-process list, and each invocation reads the whole blob, grows it, and writes it back. Memory then scales with the *total* items processed, not with one batch — and the parse→concat→dump cycle holds 2–3 copies of the blob at peak.
+
+```python
+# BAD - the cache entry accumulates EVERY matched row across all pages/runs.
+# Each call holds the raw JSON bytes + the parsed list + the re-serialized dump
+# simultaneously; the list grows unbounded and lingers for the whole TTL.
+def advance_scan(self, days):
+    cache = get_cache()
+    key = scan_cache_key(days)
+    state = json.loads(cache.get(key) or "{}")        # full list into memory
+    new_rows = fetch_page(...)
+    state["entries"] = state.get("entries", []) + new_rows   # list copy — 2 copies live
+    cache.set(key, json.dumps(state), timeout_seconds=DAY)   # full dump — 3rd copy
+    return state["entries"]                            # returns the whole accumulation
+
+# GOOD - persist only the cursor/metadata; process each page and let it go.
+def advance_scan(self, days):
+    cache = get_cache()
+    key = scan_cache_key(days)
+    state = json.loads(cache.get(key) or '{"offset": 0, "complete": false}')
+    page = fetch_page(offset=state["offset"], limit=PAGE_SIZE)   # only this page in memory
+    process(page)                                                # act on it now, don't retain
+    state["offset"] += len(page)
+    state["complete"] = len(page) < PAGE_SIZE
+    cache.set(key, json.dumps(state), timeout_seconds=SHORT_TTL) # bounded blob: cursor only
+    return state
+```
+
+Rules:
+- Store **cursor/metadata** (`offset`, `total`, `complete`), never the accumulated payload. Re-fetch each page and process it in place.
+- If you must emit accumulated output, flush it downstream **in batches**, don't hold one giant list for the whole run (this also keeps effect batches under the ceiling — see "Canvas Execution Limits").
+- Keep the TTL short and scoped to the job window so stale blobs don't linger; concurrent invocations each pay the full copy cost, so per-batch bounds matter.
+
+---
+
+## Write Amplification & Idempotency
+
+The read-focused advice above does nothing for write load. Sync, webhook, and reconcile paths can re-write the same rows over and over, and in Canvas each write can *cascade* (a saved appointment triggers `AppointmentSyncHandler.compute()`, which can trigger an external push). Two real incidents: (a) an inbound webhook re-issued a `ScheduleEvent.update()` for an admin hold **every time** an unchanged event reappeared in a delta — a large share of appointment-table write load; (b) a non-converging importer minted 331k holds for 202k distinct events and drove ~5M `compute()` runs/day (baseline ~3k/day).
+
+### 1. Guard writes with a content hash (no-op guard)
+
+```python
+# BAD - re-saves on every delivery, even when nothing changed
+def apply_inbound(event):
+    ScheduleEvent(id=mapping.event_id).update(...)   # UPDATE every time
+
+# GOOD - skip the write when content is unchanged; record the hash on create AND update
+def apply_inbound(event):
+    new_hash = google_event_content_hash(event)
+    if mapping.last_applied_hash == new_hash:
+        stats["holds_unchanged"] += 1
+        return                                       # no-op: no UPDATE issued
+    ScheduleEvent(id=mapping.event_id).update(...)
+    mapping.last_applied_hash = new_hash
+    mapping.save()
+```
+
+### 2. Make sync/import converge and be idempotent
+
+An importer that can create a new row for an event it already imported will never converge. Deduplicate on a stable external key, bound recurring expansion to a fixed window, and treat "already imported, unchanged" as a no-op. Watch for feedback loops: a write that re-triggers the handler that made the write.
+
+### 3. Bound reconcile work to what changed
+
+"Delete all + recreate all" reconcilers are O(everything) on every trigger. Scope the work to the affected window.
+
+```python
+# BAD - on every booking, deletes and recreates buffers for EVERY future appointment
+# on the provider — thousands of effects per booking on a busy provider, stalls the flow.
+def reconcile_buffers(appt):
+    Event.objects.filter(calendar__id__in=cals, title="Buffer").delete()
+    for a in Appointment.objects.filter(provider=appt.provider, start_time__gte=now):
+        create_buffer(a)
+
+# GOOD - bound both the delete and the recreate to the triggering appointment's UTC day
+# (padded by the buffer size). Per-booking work becomes O(appointments that day).
+def reconcile_buffers(appt):
+    day_start = appt.start_time.astimezone(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end = day_start + timedelta(days=1)
+    pad = timedelta(minutes=max(pre, post) + 1)
+    Event.objects.filter(calendar__id__in=cals, title="Buffer",
+                         starts_at__gte=day_start - pad, starts_at__lt=day_end + pad).delete()
+    for a in Appointment.objects.filter(provider=appt.provider,
+                                        start_time__gte=day_start, start_time__lt=day_end):
+        create_buffer(a)
+```
+
+Note the correctness trap that exposed this one: FHIR-booked appointments (e.g. via mental-health-scheduler) attach the patient as the Appointment `subject`, so `patient_id` is **null** on essentially every such row. A `patient__isnull=False` filter silently matched ~0 appointments. Don't filter visits on `patient_id` when they may be FHIR-booked.
+
+---
+
+## Canvas Execution Limits
+
+These are Canvas-runtime constraints, not Django ones — generic ORM advice will not surface them.
+
+### 1. Custom-data (SDK) models are keyed on `dbid`, not `id`
+
+`Count("id")`, `order_by("id")`, or any `"id"` reference on a custom-data model raises `FieldError: Cannot resolve keyword 'id' into field`. Use `dbid` (the primary key on `canvas_sdk.v1.data.base.Model`).
+
+```python
+# BAD - custom-data model has no `id` field → FieldError, 500s the page
+AppointmentEventMapping.objects.values("google_calendar_id").annotate(n=Count("id"))
+# GOOD
+AppointmentEventMapping.objects.values("google_calendar_id").annotate(n=Count("dbid"))
+```
+
+Tests that `patch(...objects...)` never resolve the real field name, so a broken `Count("id")` passes in CI while failing against a live DB. A query/field change needs a test that hits real field resolution (or at least asserts the field name), not a mocked queryset.
+
+### 2. The 64 MB effect-batch ceiling — chunk large fan-out through a queue + cron
+
+Effects are applied by the platform **only after the handler returns**, as a single batch. One handler that returns tens of thousands of effects crosses the 64 MB gRPC message ceiling and the whole batch is **silently dropped** — the plugin logs all the work as done, but nothing lands. Scaling the worker cannot fix this; it is a batching problem.
+
+```python
+# BAD - "re-import all": one handler computes the whole roster and returns every effect.
+# 32k+ hold effects in one batch → exceeds 64 MB gRPC ceiling → dropped, ~nothing persists.
+def reimport_all(self):
+    effects = []
+    for provider in all_providers():
+        effects += rebuild_holds(provider)   # tens of thousands of effects
+    return effects
+
+# GOOD - enqueue one unit of work per provider; a cron drains a bounded number per run,
+# so each handler invocation returns a small effect batch that fits under the ceiling.
+def reimport_all(self):
+    for provider in all_providers():
+        ReimportQueue.objects.get_or_create(provider_id=provider.id)   # idempotent
+    return []
+
+def drain_reimport(self):   # cron, e.g. every minute
+    for row in ReimportQueue.objects.all()[:BATCH]:
+        apply(rebuild_holds(row.provider_id))
+        row.delete()
+```
+
+Rule: any handler that emits effects proportional to an unbounded queryset (all providers, all patients, all appointments) must chunk the work — queue + cron, or paginate — never return one giant batch.
+
+---
+
 ## Detection Checklist
 
 When reviewing plugin code, look for:
 
-### High Priority (Likely N+1 or Memory Issues)
+### High Priority (Likely N+1, Memory, Write, or Correctness Issues)
 - [ ] `for` loops that call `.objects.get()` or `.objects.filter()` inside
 - [ ] Accessing `.related_name` or reverse relations inside loops without prefetch
 - [ ] Accessing ForeignKey attributes inside loops without select_related
 - [ ] `list()` wrapping large or unbounded querysets (e.g., `list(Model.objects.all()...)`)
 - [ ] `.all()` iterations without `.iterator()` on large tables (Patient, Note, Appointment, etc.)
+- [ ] **Over-hydration:** loading a large text/JSON blob column (`_body`, `*_json`, `*_data`, `payload`, `content`, HTML/document field) that the code path never uses → `.defer(...)` / `.only(...)` / `.values(...)`
+- [ ] **Over-hydration:** `select_related(<fk>)` on a large relation where the only downstream use is `.dbid`/`.id` → replace with the `<fk>_id` column
+- [ ] **Over-hydration:** hot list endpoint hydrating full model instances instead of `.values()`/`.only()` projections
+- [ ] **Write amplification:** `.update()`/`.save()` in a sync/webhook/reconcile path with no content-hash or change guard
+- [ ] **Unbounded reconcile:** "delete all + recreate all" not scoped to the changed window/day
+- [ ] **Cache/state accumulator:** a resumable/cron job storing all results-so-far in one cache entry or in-process list (read → concat → re-serialize each call) instead of persisting only the cursor/metadata
+- [ ] **Effect-batch ceiling:** a handler returning effects proportional to an unbounded queryset (all providers/patients/appointments) instead of chunking via queue+cron
+- [ ] **Custom-data PK:** `Count("id")` / `order_by("id")` / any `"id"` reference on a custom-data (SDK) model → use `dbid`
 
 ### Medium Priority (Potential Issues)
 - [ ] Multiple queries that could be combined with `Q` objects
 - [ ] `.count()` or `.exists()` called inside loops
 - [ ] Fetching full objects when only IDs or counts are needed
 - [ ] `.all()` or broad `.filter()` without `.only()` when only a few fields are used
+- [ ] Serializer/read contract not locked (no `FIELDS` frozenset + test) on a hot endpoint, so it can silently regrow
+- [ ] Filtering visits on `patient_id`/`patient__isnull` when they may be FHIR-booked (patient is the `subject`, so `patient_id` is null)
+- [ ] Query/field changes covered only by tests that `patch(...objects...)` (mocked querysets never resolve real field names)
+- [ ] Non-converging / non-idempotent importer (can re-create an already-imported record)
 
 ### Low Priority (Optimization Opportunities)
 - [ ] Queries that could benefit from database indexes
@@ -292,12 +513,16 @@ When reviewing, report findings as:
 
 ### Findings
 
-| Severity | Issue | Location | Recommendation |
-|----------|-------|----------|----------------|
-| HIGH | N+1 query in patient loop | handlers/handler.py:45 | Add prefetch_related('conditions') |
-| HIGH | Query inside for loop | handlers/handler.py:67 | Move query outside loop, use filter(id__in=) |
-| MEDIUM | Missing select_related | api/routes.py:23 | Add select_related('patient') |
-| LOW | Fetching all fields | handlers/handler.py:12 | Consider .only() for needed fields |
+| Severity | Axis | Issue | Location | Recommendation |
+|----------|------|-------|----------|----------------|
+| HIGH | Read count | N+1 query in patient loop | handlers/handler.py:45 | Add prefetch_related('conditions') |
+| HIGH | Memory | Note._body loaded for a list that never reads it | api/routes.py:19 | .defer("_body") or .only(needed fields) |
+| HIGH | Memory | select_related('note') only used for note.dbid | api/routes.py:23 | Drop the join; read appt.note_id |
+| HIGH | Write | update() in webhook path with no change guard | inbound.py:88 | Add content-hash no-op guard |
+| HIGH | Exec limit | Count("id") on custom-data model | routes/admin.py:31 | Use Count("dbid") |
+| HIGH | Exec limit | handler returns effects for all providers | protocols/reimport.py:20 | Chunk via queue + cron |
+| MEDIUM | Read count | Missing select_related | api/routes.py:52 | Add select_related('patient') |
+| LOW | Memory | Fetching all fields | handlers/handler.py:12 | Consider .only()/.values() for needed fields |
 
 ### Query Analysis
 

--- a/canvas-plugin-assistant/skills/plugin-patterns/SKILL.md
+++ b/canvas-plugin-assistant/skills/plugin-patterns/SKILL.md
@@ -25,3 +25,5 @@ Use this skill when you need:
 ## Quick Reference
 
 Reference the `patterns_context.txt` file for detailed patterns and examples.
+
+> **Effects are applied only after the handler returns, as a single batch capped at 64 MB (gRPC).** A handler that emits effects proportional to an unbounded queryset (all providers/patients/appointments) can exceed that ceiling, and the entire batch is **silently dropped** — the plugin logs the work as done but nothing lands. Scaling the worker does not fix this; it is a batching problem. Chunk large fan-out through a queue + cron (one small effect batch per invocation). See the **database-performance** skill (§"Canvas Execution Limits") for the full pattern, plus the write-amplification and over-hydration/memory failure modes that don't show up as N+1.


### PR DESCRIPTION
## Summary

Distills lessons from **six performance PRs merged in `gtm-extensions` over the last two weeks** (go-live incidents on production instances) into the `database-performance` skill and its review command. The skill previously only recognized one failure mode — **N+1 read counts** — but every one of those PRs was a *different* mode that adding `select_related` does not fix.

### Source PRs (gtm-extensions)
| PR | Failure mode | Root cause |
|----|--------------|-----------|
| #449 | Over-hydration / memory | `select_related("note")` hydrated the whole clinical Note per row just to read `note.dbid` → ~80MB request spikes, container memkills |
| #429 | Unbounded reconcile | delete-all + recreate-all future buffers on every booking → thousands of effects per booking |
| #454 | Exec limit | `Count("id")` on a custom-data model (PK is `dbid`) → `FieldError`; test mocked the ORM so it passed while broken |
| #439 | Write amplification | re-issued `UPDATE` for unchanged events on every delta → large share of appointment-table write load |
| #441 | Non-convergent sync | unbounded recurring expansion → hundreds of thousands of duplicate holds, millions of `compute()` runs/day |
| #470 | Effect-batch ceiling | one handler returned tens of thousands of effects in a single batch → crossed 64MB gRPC limit, silently dropped |

## Changes
- **`database-performance/SKILL.md`** — reframed from "N+1 detection" to a set of **distinct failure modes** (read count, over-hydration/memory, unbounded state accumulation, write amplification, Canvas exec limits); added a **"When more queries is BETTER"** note and a **"diagnose/measure before you grep"** section; broadened the description.
- **`database-performance/performance_context.txt`** — new sections (Over-Hydration & Memory; Accumulating Unbounded State Across Invocations; Write Amplification & Idempotency; Canvas Execution Limits) with BAD/GOOD examples drawn from the PRs; expanded detection checklist and reporting table with an "axis" column.
- **`commands/database-performance-review.md`** — added a measure-first step, extended the grep gauntlet (blob columns, cache/state accumulators, select_related-for-id, `Count("id")` on custom-data, unguarded writes in sync/webhook paths, effect batches over unbounded querysets, mocked-ORM tests), and broadened the report summary categories.
- **`custom-data-patterns/SKILL.md`** / **`plugin-patterns/SKILL.md`** — one-line cross-links to the `dbid` PK gotcha and the 64MB effect-batch ceiling, since those bite outside perf reviews too.

### Emphasis: large text/JSON blob columns
Called out prominently as the top over-hydration offender at the **column** level (the `Note.dbid` case one level down). A single large blob field — `Note._body`, `*_json`, `payload`, HTML/document fields — can dwarf every other column on a row, so loading it across hundreds/thousands of rows is a memory blowout **even at a perfect query count**. Guidance: never load such a column unless the code path actually reads it — default to `.defer("_body", ...)`, `.only(...)` the small fields, or `.values(...)` for scalars, and watch for joins/prefetches that pull relations carrying a blob column.

### Memory beyond queries: accumulating unbounded state
Added a section for a memory failure mode that isn't a query at all but surfaces in the same investigations: a resumable/cron job that keeps all results-so-far in **one cache blob or in-process list**, reading → concatenating → re-serializing the whole thing every call. Memory then scales with total items processed (not per batch), and the parse→concat→dump cycle holds 2–3 copies at peak. Fix: persist only the cursor/metadata (`offset`, `total`, `complete`), process each page in place, and flush accumulated output downstream in batches.

Docs/prompt-only change — no plugin runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)