### PR TITLE
Add description: frontmatter to all CPA commands

### DIFF
--- a/canvas-plugin-assistant/commands/analyze-instance.md
+++ b/canvas-plugin-assistant/commands/analyze-instance.md
@@ -1,5 +1,6 @@
 ---
 name: analyze-instance
+description: Analyze a Canvas instance's configuration to understand the target environment.
 ---
 
 # Analyze Instance

--- a/canvas-plugin-assistant/commands/check-setup.md
+++ b/canvas-plugin-assistant/commands/check-setup.md
@@ -1,5 +1,6 @@
 ---
 name: check-setup
+description: Verify the development environment has all required tools and configuration before starting plugin development.
 ---
 
 # Check Setup

--- a/canvas-plugin-assistant/commands/coverage.md
+++ b/canvas-plugin-assistant/commands/coverage.md
@@ -1,5 +1,6 @@
 ---
 name: coverage
+description: Run tests with coverage and offer to improve if below 90%.
 ---
 
 # Test Coverage Report

--- a/canvas-plugin-assistant/commands/create-icon.md
+++ b/canvas-plugin-assistant/commands/create-icon.md
@@ -1,5 +1,6 @@
 ---
 name: create-icon
+description: Generate an SVG icon from a description and automatically convert it to 48x48 PNG format.
 ---
 
 # Create Icon

--- a/canvas-plugin-assistant/commands/database-performance-review.md
+++ b/canvas-plugin-assistant/commands/database-performance-review.md
@@ -1,5 +1,6 @@
 ---
 name: database-performance-review
+description: Review Canvas plugin for database query performance issues, focusing on N+1 queries and ORM optimization.
 ---
 
 # Database Performance Review

--- a/canvas-plugin-assistant/commands/deploy-lite.md
+++ b/canvas-plugin-assistant/commands/deploy-lite.md
@@ -1,5 +1,6 @@
 ---
 name: deploy-lite
+description: Quick-deploy the current plugin to a Canvas instance — no version bump, no tests, no commit. Just install and monitor logs.
 ---
 
 # Deploy Lite

--- a/canvas-plugin-assistant/commands/deploy.md
+++ b/canvas-plugin-assistant/commands/deploy.md
@@ -1,5 +1,6 @@
 ---
 name: deploy
+description: Deploy the current plugin to a Canvas instance with log monitoring.
 ---
 
 # Deploy Plugin

--- a/canvas-plugin-assistant/commands/new-plugin.md
+++ b/canvas-plugin-assistant/commands/new-plugin.md
@@ -1,5 +1,6 @@
 ---
 name: new-plugin
+description: Start the plugin brainstorming process to transform requirements into a concrete specification, then implement it. Also supports updating an existing plugin with version bumping.
 ---
 
 # New Plugin

--- a/canvas-plugin-assistant/commands/run-evals.md
+++ b/canvas-plugin-assistant/commands/run-evals.md
@@ -1,5 +1,6 @@
 ---
 name: run-evals
+description: Execute eval cases to verify that security and database performance review commands correctly detect known issues.
 ---
 
 # Run Evals

--- a/canvas-plugin-assistant/commands/security-review.md
+++ b/canvas-plugin-assistant/commands/security-review.md
@@ -1,5 +1,6 @@
 ---
 name: security-review
+description: Comprehensive security audit for Canvas plugins covering both server-side API security and client-side FHIR API security.
 ---
 
 # Security Review

--- a/canvas-plugin-assistant/commands/wrap-up.md
+++ b/canvas-plugin-assistant/commands/wrap-up.md
@@ -1,5 +1,6 @@
 ---
 name: wrap-up
+description: Final checklist before calling a plugin "done" for this version.
 ---
 
 # Wrap Up Plugin


### PR DESCRIPTION
#### Problem

When the `canvas-plugin-assistant` plugin is used from a programmatic Claude session (Claude Agent SDK / headless Claude Code) and the model is asked to run a command such as `/cpa:deploy-lite`, the model can refuse with:

> The `/cpa:deploy-lite` command isn't available to me, so I can't run it.

The command is installed and loads correctly - it appears in the session's slash_commands init metadata, and the Skill tool will execute it if called. The refusal happens because commands without a description: `frontmatter` field never surface in the model-visible skills/commands listing, and the harness instructs the model to only invoke what is listed and not to guess names. Whether the model tries anyway is a judgment call: sessions that have previously seen the command succeed will use it, while fresh sessions tend to refuse. This makes automated flows that instruct the agent to run a CPA command fail nondeterministically - typically on the first attempt in a new session.

Interactive use (a human typing `/cpa:deploy-lite`) is unaffected either way.

#### Fix

Add a description: field to the `frontmatter` of all commands. Each description is taken verbatim from the command's existing intro line, so no new wording is introduced:


> name: deploy-lite
>description: Quick-deploy the current plugin to a Canvas instance - no version bump, no tests, no commit. Just install and monitor logs.


With the description present, the commands appear in the model-visible listing and model-driven invocation works reliably in fresh sessions.

#### Scope

- 11 files changed, 1 line inserted in each (`canvas-plugin-assistant/commands/*.md`)
- No changes to command bodies, arguments, or behavior
